### PR TITLE
feat(html): add content transformation utilities for HTML-to-Markdown…

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,9 @@
 {
-    "editor.formatOnSave": true,
-    "editor.defaultFormatter": "biomejs.biome",
     "editor.codeActionsOnSave": {
         "source.fixAll.biome": "explicit",
         "source.organizeImports.biome": "explicit"
     },
+    "editor.defaultFormatter": "biomejs.biome",
+    "editor.formatOnSave": true,
     "npm.packageManager": "bun"
 }

--- a/AGENTS.MD
+++ b/AGENTS.MD
@@ -4,15 +4,28 @@ Welcome to the `ketab-online-sdk` repository. This document captures the convent
 
 ## Repository layout
 
-- `src/index.ts` exposes the public API (`downloadBook`, `getBookIndex`, `getBooks`, etc.). All TypeScript helpers must be documented with JSDoc.
+- `src/index.ts` exposes the browser-compatible public API (`getBookIndex`, `getBooks`, `getBookContents`, etc.). All TypeScript helpers must be documented with JSDoc.
+- `src/node.ts` exposes Node.js-only functions (`downloadBook`) and re-exports everything from `index.ts`. This is a separate entry point for consumers who need filesystem operations.
 - `src/types.ts` contains all TypeScript type definitions for API requests and responses.
 - `src/utils/` contains shared utilities:
   - `common.ts` – data transforms such as `removeFalsyValues`.
-  - `io.ts` – filesystem helpers (`createTempDir`, `unzipFromUrl`).
-  - `network.ts` – HTTP helpers (`httpsGet`, `buildUrl`).
+  - `io.ts` – in-memory ZIP extraction using `fflate` (`unzipFromUrl`). Browser-compatible.
+  - `network.ts` – HTTP helpers using the Fetch API (`httpsGet`, `buildUrl`). Browser-compatible.
 - `testing/e2e.test.ts` exercises the remote API. It is skipped in CI but useful for manual verification.
-- `tsdown.config.ts` defines the bundler options. Update it whenever the build target or entry points change.
+- `tsdown.config.ts` defines the bundler options with dual entry points (`src/index.ts`, `src/node.ts`).
 - Tooling configs (`biome.json`, `tsconfig.json`, `release.config.mjs`) live at the repo root.
+
+## Browser compatibility
+
+The SDK is designed to work in browsers and modern JavaScript runtimes:
+
+- **Main entry (`ketab-online-sdk`)**: Uses the Fetch API and `fflate` for in-memory ZIP extraction. No Node.js-specific APIs.
+- **Node entry (`ketab-online-sdk/node`)**: Adds `downloadBook` which requires `node:fs/promises`. Re-exports everything from the main entry for convenience.
+
+When modifying the codebase:
+- Keep `src/index.ts` free of Node.js-specific imports (`node:fs`, `node:os`, `node:path`, `node:https`, etc.)
+- Place Node.js-only functionality in `src/node.ts`
+- The `src/utils/` files should remain browser-compatible
 
 ## Tooling & workflow
 
@@ -108,11 +121,49 @@ beforeEach(() => {
 // No afterAll cleanup needed - mocks are automatically scoped
 ```
 
+## Mocking global fetch
+
+When testing code that uses `fetch()` directly (like `httpsGet` in `network.ts`), you need special handling:
+
+```typescript
+// Store original fetch
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+    // Restore after each test
+    globalThis.fetch = originalFetch;
+});
+
+it('should handle JSON responses', async () => {
+    // Create mock BEFORE importing the module
+    globalThis.fetch = mock(async () =>
+        new Response(JSON.stringify({ success: true }), {
+            headers: { 'content-type': 'application/json' },
+        }),
+    );
+
+    // Use cache-busting query param to get fresh module import
+    const networkModule = await import('./network?test-json');
+    const result = await networkModule.httpsGet('https://example.com');
+
+    expect(result).toEqual({ success: true });
+});
+```
+
+**Key insight**: Bun caches dynamic imports. Use unique query params (e.g., `?test-name`) to bust the cache when you need a fresh module instance with different mock behavior.
+
+## Key dependencies
+
+- **fflate**: Used for in-memory ZIP extraction. This is a pure JavaScript library that works in browsers without any polyfills. The `unzipSync` function takes a `Uint8Array` and returns an object mapping filenames to their contents as `Uint8Array`.
+
+- **Fetch API**: Used for all HTTP requests via `httpsGet`. This is natively available in browsers, Node.js 18+, Deno, and Bun. No polyfill needed for modern runtimes.
+
 ## Current API coverage
 
 The SDK currently provides access to:
 
-- **Books**: `getBookInfo`, `getBooks`, `getBookContents`, `getBookIndex`, `downloadBook`
+- **Books**: `getBookInfo`, `getBooks`, `getBookContents`, `getBookIndex`
+- **Books (Node.js only)**: `downloadBook` (via `ketab-online-sdk/node`)
 - **Authors**: `getAuthorInfo`, `getAuthors`
 - **Categories**: `getCategoryInfo`, `getCategories`
 
@@ -125,5 +176,16 @@ All endpoints support the standard ketabonline.com API parameters including pagi
 - **Sorting**: Use `sort_field` and `sort_direction` parameters
 - **Hierarchical data**: The `is_recursive` parameter (0 or 1) controls whether nested structures include children
 - **Part selection**: Multi-volume works use the `part` parameter to specify which volume
+
+## Data flow for book contents
+
+Understanding how book data flows through the SDK:
+
+1. **Download**: `httpsGet` fetches the ZIP file as `Uint8Array` via Fetch API
+2. **Extract**: `fflate.unzipSync` extracts the ZIP in memory, returning `{ [filename]: Uint8Array }`
+3. **Decode**: `TextDecoder.decode()` converts the `Uint8Array` to a UTF-8 string
+4. **Parse**: `JSON.parse()` converts the string to a JavaScript object
+
+All of these operations are browser-compatible. The only Node.js-specific operation is `fs.writeFile` in `downloadBook`, which is why that function lives in `src/node.ts`.
 
 Thanks for helping keep the project healthy!

--- a/bun.lock
+++ b/bun.lock
@@ -40,23 +40,23 @@
 
     "@babel/types": ["@babel/types@7.28.5", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA=="],
 
-    "@biomejs/biome": ["@biomejs/biome@2.3.6", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.3.6", "@biomejs/cli-darwin-x64": "2.3.6", "@biomejs/cli-linux-arm64": "2.3.6", "@biomejs/cli-linux-arm64-musl": "2.3.6", "@biomejs/cli-linux-x64": "2.3.6", "@biomejs/cli-linux-x64-musl": "2.3.6", "@biomejs/cli-win32-arm64": "2.3.6", "@biomejs/cli-win32-x64": "2.3.6" }, "bin": { "biome": "bin/biome" } }, "sha512-oqUhWyU6tae0MFsr/7iLe++QWRg+6jtUhlx9/0GmCWDYFFrK366sBLamNM7D9Y+c7YSynUFKr8lpEp1r6Sk7eA=="],
+    "@biomejs/biome": ["@biomejs/biome@2.3.10", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.3.10", "@biomejs/cli-darwin-x64": "2.3.10", "@biomejs/cli-linux-arm64": "2.3.10", "@biomejs/cli-linux-arm64-musl": "2.3.10", "@biomejs/cli-linux-x64": "2.3.10", "@biomejs/cli-linux-x64-musl": "2.3.10", "@biomejs/cli-win32-arm64": "2.3.10", "@biomejs/cli-win32-x64": "2.3.10" }, "bin": { "biome": "bin/biome" } }, "sha512-/uWSUd1MHX2fjqNLHNL6zLYWBbrJeG412/8H7ESuK8ewoRoMPUgHDebqKrPTx/5n6f17Xzqc9hdg3MEqA5hXnQ=="],
 
-    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.3.6", "", { "os": "darwin", "cpu": "arm64" }, "sha512-P4JWE5d8UayBxYe197QJwyW4ZHp0B+zvRIGCusOm1WbxmlhpAQA1zEqQuunHgSIzvyEEp4TVxiKGXNFZPg7r9Q=="],
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.3.10", "", { "os": "darwin", "cpu": "arm64" }, "sha512-M6xUjtCVnNGFfK7HMNKa593nb7fwNm43fq1Mt71kpLpb+4mE7odO8W/oWVDyBVO4ackhresy1ZYO7OJcVo/B7w=="],
 
-    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.3.6", "", { "os": "darwin", "cpu": "x64" }, "sha512-I4rTebj+F/L9K93IU7yTFs8nQ6EhaCOivxduRha4w4WEZK80yoZ8OAdR1F33m4yJ/NfUuTUbP/Wjs+vKjlCoWA=="],
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.3.10", "", { "os": "darwin", "cpu": "x64" }, "sha512-Vae7+V6t/Avr8tVbFNjnFSTKZogZHFYl7MMH62P/J1kZtr0tyRQ9Fe0onjqjS2Ek9lmNLmZc/VR5uSekh+p1fg=="],
 
-    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.3.6", "", { "os": "linux", "cpu": "arm64" }, "sha512-JjYy83eVBnvuINZiqyFO7xx72v8Srh4hsgaacSBCjC22DwM6+ZvnX1/fj8/SBiLuUOfZ8YhU2pfq2Dzakeyg1A=="],
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.3.10", "", { "os": "linux", "cpu": "arm64" }, "sha512-hhPw2V3/EpHKsileVOFynuWiKRgFEV48cLe0eA+G2wO4SzlwEhLEB9LhlSrVeu2mtSn205W283LkX7Fh48CaxA=="],
 
-    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.3.6", "", { "os": "linux", "cpu": "arm64" }, "sha512-oK1NpIXIixbJ/4Tcx40cwiieqah6rRUtMGOHDeK2ToT7yUFVEvXUGRKqH0O4hqZ9tW8TcXNZKfgRH6xrsjVtGg=="],
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.3.10", "", { "os": "linux", "cpu": "arm64" }, "sha512-B9DszIHkuKtOH2IFeeVkQmSMVUjss9KtHaNXquYYWCjH8IstNgXgx5B0aSBQNr6mn4RcKKRQZXn9Zu1rM3O0/A=="],
 
-    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.3.6", "", { "os": "linux", "cpu": "x64" }, "sha512-ZjPXzy5yN9wusIoX+8Zp4p6cL8r0NzJCXg/4r1KLVveIPXd2jKVlqZ6ZyzEq385WwU3OX5KOwQYLQsOc788waQ=="],
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.3.10", "", { "os": "linux", "cpu": "x64" }, "sha512-wwAkWD1MR95u+J4LkWP74/vGz+tRrIQvr8kfMMJY8KOQ8+HMVleREOcPYsQX82S7uueco60L58Wc6M1I9WA9Dw=="],
 
-    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.3.6", "", { "os": "linux", "cpu": "x64" }, "sha512-QvxB8GHQeaO4FCtwJpJjCgJkbHBbWxRHUxQlod+xeaYE6gtJdSkYkuxdKAQUZEOIsec+PeaDAhW9xjzYbwmOFA=="],
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.3.10", "", { "os": "linux", "cpu": "x64" }, "sha512-QTfHZQh62SDFdYc2nfmZFuTm5yYb4eO1zwfB+90YxUumRCR171tS1GoTX5OD0wrv4UsziMPmrePMtkTnNyYG3g=="],
 
-    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.3.6", "", { "os": "win32", "cpu": "arm64" }, "sha512-YM7hLHpwjdt8R7+O2zS1Vo2cKgqEeptiXB1tWW1rgjN5LlpZovBVKtg7zfwfRrFx3i08aNZThYpTcowpTlczug=="],
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.3.10", "", { "os": "win32", "cpu": "arm64" }, "sha512-o7lYc9n+CfRbHvkjPhm8s9FgbKdYZu5HCcGVMItLjz93EhgJ8AM44W+QckDqLA9MKDNFrR8nPbO4b73VC5kGGQ=="],
 
-    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.3.6", "", { "os": "win32", "cpu": "x64" }, "sha512-psgNEYgMAobY5h+QHRBVR9xvg2KocFuBKm6axZWB/aD12NWhQjiVFQUjV6wMXhlH4iT0Q9c3yK5JFRiDC/rzHA=="],
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.3.10", "", { "os": "win32", "cpu": "x64" }, "sha512-pHEFgq7dUEsKnqG9mx9bXihxGI49X+ar+UBrEIj3Wqj3UCZp1rNgV+OoyjFgcXsjCWpuEAF4VJdkZr3TrWdCbQ=="],
 
     "@colors/colors": ["@colors/colors@1.5.0", "", {}, "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ=="],
 
@@ -76,7 +76,7 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
-    "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.0.7", "", { "dependencies": { "@emnapi/core": "^1.5.0", "@emnapi/runtime": "^1.5.0", "@tybys/wasm-util": "^0.10.1" } }, "sha512-SeDnOO0Tk7Okiq6DbXmmBODgOAb9dp9gjlphokTUxmt8U3liIP1ZsozBahH69j/RJv+Rfs6IwUKHTgQYJ/HBAw=="],
+    "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.0", "", { "dependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1", "@tybys/wasm-util": "^0.10.1" } }, "sha512-Fq6DJW+Bb5jaWE69/qOE0D1TUN9+6uWhCeZpdnSBk14pjLcCWR7Q8n49PTSPHazM37JqrsdpEthXy2xn6jWWiA=="],
 
     "@octokit/auth-token": ["@octokit/auth-token@6.0.0", "", {}, "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w=="],
 
@@ -100,9 +100,7 @@
 
     "@octokit/types": ["@octokit/types@16.0.0", "", { "dependencies": { "@octokit/openapi-types": "^27.0.0" } }, "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg=="],
 
-    "@oxc-project/runtime": ["@oxc-project/runtime@0.97.0", "", {}, "sha512-yH0zw7z+jEws4dZ4IUKoix5Lh3yhqIJWF9Dc8PWvhpo7U7O+lJrv7ZZL4BeRO0la8LBQFwcCewtLBnVV7hPe/w=="],
-
-    "@oxc-project/types": ["@oxc-project/types@0.97.0", "", {}, "sha512-lxmZK4xFrdvU0yZiDwgVQTCvh2gHWBJCBk5ALsrtsBWhs0uDIi+FTOnXRQeQfs304imdvTdaakT/lqwQ8hkOXQ=="],
+    "@oxc-project/types": ["@oxc-project/types@0.103.0", "", {}, "sha512-bkiYX5kaXWwUessFRSoXFkGIQTmc6dLGdxuRTrC+h8PSnIdZyuXHHlLAeTmOue5Br/a0/a7dHH0Gca6eXn9MKg=="],
 
     "@pnpm/config.env-replace": ["@pnpm/config.env-replace@1.1.0", "", {}, "sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w=="],
 
@@ -110,37 +108,35 @@
 
     "@pnpm/npm-conf": ["@pnpm/npm-conf@2.3.1", "", { "dependencies": { "@pnpm/config.env-replace": "^1.1.0", "@pnpm/network.ca-file": "^1.0.1", "config-chain": "^1.1.11" } }, "sha512-c83qWb22rNRuB0UaVCI0uRPNRr8Z0FWnEIvT47jiHAmOIUHbBOg5XvV7pM5x+rKn9HRpjxquDbXYSXr3fAKFcw=="],
 
-    "@quansync/fs": ["@quansync/fs@0.1.5", "", { "dependencies": { "quansync": "^0.2.11" } }, "sha512-lNS9hL2aS2NZgNW7BBj+6EBl4rOf8l+tQ0eRY6JWCI8jI2kc53gSoqbjojU0OnAWhzoXiOjFyGsHcDGePB3lhA=="],
+    "@quansync/fs": ["@quansync/fs@1.0.0", "", { "dependencies": { "quansync": "^1.0.0" } }, "sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ=="],
 
-    "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.0-beta.50", "", { "os": "android", "cpu": "arm64" }, "sha512-XlEkrOIHLyGT3avOgzfTFSjG+f+dZMw+/qd+Y3HLN86wlndrB/gSimrJCk4gOhr1XtRtEKfszpadI3Md4Z4/Ag=="],
+    "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.0-beta.57", "", { "os": "android", "cpu": "arm64" }, "sha512-GoOVDy8bjw9z1K30Oo803nSzXJS/vWhFijFsW3kzvZCO8IZwFnNa6pGctmbbJstKl3Fv6UBwyjJQN6msejW0IQ=="],
 
-    "@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.0.0-beta.50", "", { "os": "darwin", "cpu": "arm64" }, "sha512-+JRqKJhoFlt5r9q+DecAGPLZ5PxeLva+wCMtAuoFMWPoZzgcYrr599KQ+Ix0jwll4B4HGP43avu9My8KtSOR+w=="],
+    "@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.0.0-beta.57", "", { "os": "darwin", "cpu": "arm64" }, "sha512-9c4FOhRGpl+PX7zBK5p17c5efpF9aSpTPgyigv57hXf5NjQUaJOOiejPLAtFiKNBIfm5Uu6yFkvLKzOafNvlTw=="],
 
-    "@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.0.0-beta.50", "", { "os": "darwin", "cpu": "x64" }, "sha512-fFXDjXnuX7/gQZQm/1FoivVtRcyAzdjSik7Eo+9iwPQ9EgtA5/nB2+jmbzaKtMGG3q+BnZbdKHCtOacmNrkIDA=="],
+    "@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.0.0-beta.57", "", { "os": "darwin", "cpu": "x64" }, "sha512-6RsB8Qy4LnGqNGJJC/8uWeLWGOvbRL/KG5aJ8XXpSEupg/KQtlBEiFaYU/Ma5Usj1s+bt3ItkqZYAI50kSplBA=="],
 
-    "@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.0.0-beta.50", "", { "os": "freebsd", "cpu": "x64" }, "sha512-F1b6vARy49tjmT/hbloplzgJS7GIvwWZqt+tAHEstCh0JIh9sa8FAMVqEmYxDviqKBaAI8iVvUREm/Kh/PD26Q=="],
+    "@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.0.0-beta.57", "", { "os": "freebsd", "cpu": "x64" }, "sha512-uA9kG7+MYkHTbqwv67Tx+5GV5YcKd33HCJIi0311iYBd25yuwyIqvJfBdt1VVB8tdOlyTb9cPAgfCki8nhwTQg=="],
 
-    "@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.0.0-beta.50", "", { "os": "linux", "cpu": "arm" }, "sha512-U6cR76N8T8M6lHj7EZrQ3xunLPxSvYYxA8vJsBKZiFZkT8YV4kjgCO3KwMJL0NOjQCPGKyiXO07U+KmJzdPGRw=="],
+    "@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.0.0-beta.57", "", { "os": "linux", "cpu": "arm" }, "sha512-3KkS0cHsllT2T+Te+VZMKHNw6FPQihYsQh+8J4jkzwgvAQpbsbXmrqhkw3YU/QGRrD8qgcOvBr6z5y6Jid+rmw=="],
 
-    "@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.0.0-beta.50", "", { "os": "linux", "cpu": "arm64" }, "sha512-ONgyjofCrrE3bnh5GZb8EINSFyR/hmwTzZ7oVuyUB170lboza1VMCnb8jgE6MsyyRgHYmN8Lb59i3NKGrxrYjw=="],
+    "@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.0.0-beta.57", "", { "os": "linux", "cpu": "arm64" }, "sha512-A3/wu1RgsHhqP3rVH2+sM81bpk+Qd2XaHTl8LtX5/1LNR7QVBFBCpAoiXwjTdGnI5cMdBVi7Z1pi52euW760Fw=="],
 
-    "@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.0.0-beta.50", "", { "os": "linux", "cpu": "arm64" }, "sha512-L0zRdH2oDPkmB+wvuTl+dJbXCsx62SkqcEqdM+79LOcB+PxbAxxjzHU14BuZIQdXcAVDzfpMfaHWzZuwhhBTcw=="],
+    "@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.0.0-beta.57", "", { "os": "linux", "cpu": "arm64" }, "sha512-d0kIVezTQtazpyWjiJIn5to8JlwfKITDqwsFv0Xc6s31N16CD2PC/Pl2OtKgS7n8WLOJbfqgIp5ixYzTAxCqMg=="],
 
-    "@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.0.0-beta.50", "", { "os": "linux", "cpu": "x64" }, "sha512-gyoI8o/TGpQd3OzkJnh1M2kxy1Bisg8qJ5Gci0sXm9yLFzEXIFdtc4EAzepxGvrT2ri99ar5rdsmNG0zP0SbIg=="],
+    "@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.0.0-beta.57", "", { "os": "linux", "cpu": "x64" }, "sha512-E199LPijo98yrLjPCmETx8EF43sZf9t3guSrLee/ej1rCCc3zDVTR4xFfN9BRAapGVl7/8hYqbbiQPTkv73kUg=="],
 
-    "@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.0.0-beta.50", "", { "os": "linux", "cpu": "x64" }, "sha512-zti8A7M+xFDpKlghpcCAzyOi+e5nfUl3QhU023ce5NCgUxRG5zGP2GR9LTydQ1rnIPwZUVBWd4o7NjZDaQxaXA=="],
+    "@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.0.0-beta.57", "", { "os": "linux", "cpu": "x64" }, "sha512-++EQDpk/UJ33kY/BNsh7A7/P1sr/jbMuQ8cE554ZIy+tCUWCivo9zfyjDUoiMdnxqX6HLJEqqGnbGQOvzm2OMQ=="],
 
-    "@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.0.0-beta.50", "", { "os": "none", "cpu": "arm64" }, "sha512-eZUssog7qljrrRU9Mi0eqYEPm3Ch0UwB+qlWPMKSUXHNqhm3TvDZarJQdTevGEfu3EHAXJvBIe0YFYr0TPVaMA=="],
+    "@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.0.0-beta.57", "", { "os": "none", "cpu": "arm64" }, "sha512-voDEBcNqxbUv/GeXKFtxXVWA+H45P/8Dec4Ii/SbyJyGvCqV1j+nNHfnFUIiRQ2Q40DwPe/djvgYBs9PpETiMA=="],
 
-    "@rolldown/binding-wasm32-wasi": ["@rolldown/binding-wasm32-wasi@1.0.0-beta.50", "", { "dependencies": { "@napi-rs/wasm-runtime": "^1.0.7" }, "cpu": "none" }, "sha512-nmCN0nIdeUnmgeDXiQ+2HU6FT162o+rxnF7WMkBm4M5Ds8qTU7Dzv2Wrf22bo4ftnlrb2hKK6FSwAJSAe2FWLg=="],
+    "@rolldown/binding-wasm32-wasi": ["@rolldown/binding-wasm32-wasi@1.0.0-beta.57", "", { "dependencies": { "@napi-rs/wasm-runtime": "^1.1.0" }, "cpu": "none" }, "sha512-bRhcF7NLlCnpkzLVlVhrDEd0KH22VbTPkPTbMjlYvqhSmarxNIq5vtlQS8qmV7LkPKHrNLWyJW/V/sOyFba26Q=="],
 
-    "@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.0.0-beta.50", "", { "os": "win32", "cpu": "arm64" }, "sha512-7kcNLi7Ua59JTTLvbe1dYb028QEPaJPJQHqkmSZ5q3tJueUeb6yjRtx8mw4uIqgWZcnQHAR3PrLN4XRJxvgIkA=="],
+    "@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.0.0-beta.57", "", { "os": "win32", "cpu": "arm64" }, "sha512-rnDVGRks2FQ2hgJ2g15pHtfxqkGFGjJQUDWzYznEkE8Ra2+Vag9OffxdbJMZqBWXHVM0iS4dv8qSiEn7bO+n1Q=="],
 
-    "@rolldown/binding-win32-ia32-msvc": ["@rolldown/binding-win32-ia32-msvc@1.0.0-beta.50", "", { "os": "win32", "cpu": "ia32" }, "sha512-lL70VTNvSCdSZkDPPVMwWn/M2yQiYvSoXw9hTLgdIWdUfC3g72UaruezusR6ceRuwHCY1Ayu2LtKqXkBO5LIwg=="],
+    "@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.0.0-beta.57", "", { "os": "win32", "cpu": "x64" }, "sha512-OqIUyNid1M4xTj6VRXp/Lht/qIP8fo25QyAZlCP+p6D2ATCEhyW4ZIFLnC9zAGN/HMbXoCzvwfa8Jjg/8J4YEg=="],
 
-    "@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.0.0-beta.50", "", { "os": "win32", "cpu": "x64" }, "sha512-4qU4x5DXWB4JPjyTne/wBNPqkbQU8J45bl21geERBKtEittleonioACBL1R0PsBu0Aq21SwMK5a9zdBkWSlQtQ=="],
-
-    "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-beta.50", "", {}, "sha512-5e76wQiQVeL1ICOZVUg4LSOVYg9jyhGCin+icYozhsUzM+fHE7kddi1bdiE0jwVqTfkjba3jUFbEkoC9WkdvyA=="],
+    "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-beta.57", "", {}, "sha512-aQNelgx14tGA+n2tNSa9x6/jeoCL9fkDeCei7nOKnHx0fEFRRMu5ReiITo+zZD5TzWDGGRjbSYCs93IfRIyTuQ=="],
 
     "@sec-ant/readable-stream": ["@sec-ant/readable-stream@0.4.1", "", {}, "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg=="],
 
@@ -164,13 +160,11 @@
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
-    "@types/bun": ["@types/bun@1.3.2", "", { "dependencies": { "bun-types": "1.3.2" } }, "sha512-t15P7k5UIgHKkxwnMNkJbWlh/617rkDGEdSsDbu+qNHTaz9SKf7aC8fiIlUdD5RPpH6GEkP0cK7WlvmrEBRtWg=="],
+    "@types/bun": ["@types/bun@1.3.5", "", { "dependencies": { "bun-types": "1.3.5" } }, "sha512-RnygCqNrd3srIPEWBd5LFeUYG7plCoH2Yw9WaZGyNmdTEei+gWaHqydbaIRkIkcbXwhBT94q78QljxN0Sk838w=="],
 
-    "@types/node": ["@types/node@24.10.1", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ=="],
+    "@types/node": ["@types/node@25.0.3", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA=="],
 
     "@types/normalize-package-data": ["@types/normalize-package-data@2.4.4", "", {}, "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA=="],
-
-    "@types/react": ["@types/react@19.2.5", "", { "dependencies": { "csstype": "^3.0.2" } }, "sha512-keKxkZMqnDicuvFoJbzrhbtdLSPhj/rZThDlKWCDbgXmUg0rEUFtRssDXKYmtXluZlIqiC5VqkCgRwzuyLHKHw=="],
 
     "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
@@ -196,13 +190,13 @@
 
     "before-after-hook": ["before-after-hook@4.0.0", "", {}, "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ=="],
 
-    "birpc": ["birpc@2.8.0", "", {}, "sha512-Bz2a4qD/5GRhiHSwj30c/8kC8QGj12nNDwz3D4ErQ4Xhy35dsSDvF+RA/tWpjyU0pdGtSDiEk6B5fBGE1qNVhw=="],
+    "birpc": ["birpc@4.0.0", "", {}, "sha512-LShSxJP0KTmd101b6DRyGBj57LZxSDYWKitQNW/mi8GRMvZb078Uf9+pveax1DrVL89vm7mWe+TovdI/UDOuPw=="],
 
     "bottleneck": ["bottleneck@2.19.5", "", {}, "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
-    "bun-types": ["bun-types@1.3.2", "", { "dependencies": { "@types/node": "*" }, "peerDependencies": { "@types/react": "^19" } }, "sha512-i/Gln4tbzKNuxP70OWhJRZz1MRfvqExowP7U6JKoI8cntFrtxg7RJK3jvz7wQW54UuvNC8tbKHHri5fy74FVqg=="],
+    "bun-types": ["bun-types@1.3.5", "", { "dependencies": { "@types/node": "*" } }, "sha512-inmAYe2PFLs0SUbFOWSVD24sg1jFlMPxOjOSSCYqUgn4Hsc3rDc7dFvfVYjFPNHtov6kgUeulV4SxbuIV/stPw=="],
 
     "cac": ["cac@6.7.14", "", {}, "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ=="],
 
@@ -211,8 +205,6 @@
     "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
     "char-regex": ["char-regex@1.0.2", "", {}, "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw=="],
-
-    "chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
 
     "clean-stack": ["clean-stack@2.2.0", "", {}, "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A=="],
 
@@ -248,13 +240,11 @@
 
     "crypto-random-string": ["crypto-random-string@4.0.0", "", { "dependencies": { "type-fest": "^1.0.1" } }, "sha512-x8dy3RnvYdlUcPOjkEHqozhiwzKNSq7GcPuXFbnyMOCHxX8V3OgIg/pYuabl2sbUPfIJaeAQB7PMOK8DFIdoRA=="],
 
-    "csstype": ["csstype@3.2.1", "", {}, "sha512-98XGutrXoh75MlgLihlNxAGbUuFQc7l1cqcnEZlLNKc0UrVdPndgmaDmYTDDh929VS/eqTZV0rozmhu2qqT1/g=="],
-
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "deep-extend": ["deep-extend@0.6.0", "", {}, "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="],
 
-    "diff": ["diff@8.0.2", "", {}, "sha512-sSuxWU5j5SR9QQji/o2qMvqRNYRDOcBTgsJ/DeCf4iSN4gW+gNMXM7wFIP+fdXZxoNiAnHUTGjCr+TSWXdRDKg=="],
+    "defu": ["defu@6.1.4", "", {}, "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg=="],
 
     "dir-glob": ["dir-glob@3.0.1", "", { "dependencies": { "path-type": "^4.0.0" } }, "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA=="],
 
@@ -326,7 +316,7 @@
 
     "hook-std": ["hook-std@4.0.0", "", {}, "sha512-IHI4bEVOt3vRUDJ+bFA9VUJlo7SzvFARPNLw75pqSmAOP2HmTWfFJtPvLBrDrlgjEYXY9zs7SFdHPQaJShkSCQ=="],
 
-    "hookable": ["hookable@5.5.3", "", {}, "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ=="],
+    "hookable": ["hookable@6.0.1", "", {}, "sha512-uKGyY8BuzN/a5gvzvA+3FVWo0+wUjgtfSdnmjtrOVwQCZPHpHDH2WRO3VZSOeluYrHoDCiXFffZXs8Dj1ULWtw=="],
 
     "hosted-git-info": ["hosted-git-info@9.0.2", "", { "dependencies": { "lru-cache": "^11.1.0" } }, "sha512-M422h7o/BR3rmCQ8UHi7cyyMqKltdP9Uo+J2fXK+RSAY+wTcKOIRyhTuKv4qn+DJf3g+PL890AzId5KZpX+CBg=="],
 
@@ -341,6 +331,8 @@
     "import-from-esm": ["import-from-esm@2.0.0", "", { "dependencies": { "debug": "^4.3.4", "import-meta-resolve": "^4.0.0" } }, "sha512-YVt14UZCgsX1vZQ3gKjkWVdBdHQ6eu3MPU1TBgL1H5orXe2+jWD006WCPPtOuwlQm10NuzOW5WawiF1Q9veW8g=="],
 
     "import-meta-resolve": ["import-meta-resolve@4.2.0", "", {}, "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg=="],
+
+    "import-without-cache": ["import-without-cache@0.2.5", "", {}, "sha512-B6Lc2s6yApwnD2/pMzFh/d5AVjdsDXjgkeJ766FmFuJELIGHNycKRj+l3A39yZPM4CchqNCB4RITEAYB1KUM6A=="],
 
     "indent-string": ["indent-string@4.0.0", "", {}, "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="],
 
@@ -408,8 +400,6 @@
 
     "lru-cache": ["lru-cache@11.2.2", "", {}, "sha512-F9ODfyqML2coTIsQpSkRHnLSZMtkU8Q+mSfcaIyKwy58u+8k5nvAYeiNhsyMARvzNcXJ9QfWVrcPsC9e9rAxtg=="],
 
-    "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
-
     "make-asynchronous": ["make-asynchronous@1.0.1", "", { "dependencies": { "p-event": "^6.0.0", "type-fest": "^4.6.0", "web-worker": "1.2.0" } }, "sha512-T9BPOmEOhp6SmV25SwLVcHK4E6JyG/coH3C6F1NjNXSziv/fd4GmsqMk8YR6qpPOswfaOCApSNkZv6fxoaYFcQ=="],
 
     "marked": ["marked@15.0.12", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA=="],
@@ -448,7 +438,7 @@
 
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 
-    "obug": ["obug@2.0.0", "", { "peerDependencies": { "ms": "^2.0.0" }, "optionalPeers": ["ms"] }, "sha512-dpSQuPXoKUjulinHmXjZV1YIRhOLEqBl1J6PYi9mRQR2dYcSK+OULRr+GuT1vufk2f40mtIOqmSL/aTikjmq5Q=="],
+    "obug": ["obug@2.1.1", "", {}, "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ=="],
 
     "onetime": ["onetime@5.1.2", "", { "dependencies": { "mimic-fn": "^2.1.0" } }, "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg=="],
 
@@ -492,7 +482,7 @@
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
-    "picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
+    "picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
 
     "pify": ["pify@3.0.0", "", {}, "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg=="],
 
@@ -504,7 +494,7 @@
 
     "proto-list": ["proto-list@1.2.4", "", {}, "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA=="],
 
-    "quansync": ["quansync@0.2.11", "", {}, "sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA=="],
+    "quansync": ["quansync@1.0.0", "", {}, "sha512-5xZacEEufv3HSTPQuchrvV6soaiACMFnq1H8wkVioctoH3TRha9Sz66lOxRwPK/qZj7HPiSveih9yAyh98gvqA=="],
 
     "rc": ["rc@1.2.8", "", { "dependencies": { "deep-extend": "^0.6.0", "ini": "~1.3.0", "minimist": "^1.2.0", "strip-json-comments": "~2.0.1" }, "bin": { "rc": "./cli.js" } }, "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw=="],
 
@@ -514,8 +504,6 @@
 
     "readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
 
-    "readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
-
     "registry-auth-token": ["registry-auth-token@5.1.0", "", { "dependencies": { "@pnpm/npm-conf": "^2.1.0" } }, "sha512-GdekYuwLXLxMuFTwAPg5UKGLW/UXzQrZvH/Zj791BQif5T05T0RsaLfHc9q3ZOKi7n+BoprPD9mJ0O0k4xzUlw=="],
 
     "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
@@ -524,9 +512,9 @@
 
     "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="],
 
-    "rolldown": ["rolldown@1.0.0-beta.50", "", { "dependencies": { "@oxc-project/types": "=0.97.0", "@rolldown/pluginutils": "1.0.0-beta.50" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.0-beta.50", "@rolldown/binding-darwin-arm64": "1.0.0-beta.50", "@rolldown/binding-darwin-x64": "1.0.0-beta.50", "@rolldown/binding-freebsd-x64": "1.0.0-beta.50", "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-beta.50", "@rolldown/binding-linux-arm64-gnu": "1.0.0-beta.50", "@rolldown/binding-linux-arm64-musl": "1.0.0-beta.50", "@rolldown/binding-linux-x64-gnu": "1.0.0-beta.50", "@rolldown/binding-linux-x64-musl": "1.0.0-beta.50", "@rolldown/binding-openharmony-arm64": "1.0.0-beta.50", "@rolldown/binding-wasm32-wasi": "1.0.0-beta.50", "@rolldown/binding-win32-arm64-msvc": "1.0.0-beta.50", "@rolldown/binding-win32-ia32-msvc": "1.0.0-beta.50", "@rolldown/binding-win32-x64-msvc": "1.0.0-beta.50" }, "bin": { "rolldown": "bin/cli.mjs" } }, "sha512-JFULvCNl/anKn99eKjOSEubi0lLmNqQDAjyEMME2T4CwezUDL0i6t1O9xZsu2OMehPnV2caNefWpGF+8TnzB6A=="],
+    "rolldown": ["rolldown@1.0.0-beta.57", "", { "dependencies": { "@oxc-project/types": "=0.103.0", "@rolldown/pluginutils": "1.0.0-beta.57" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.0-beta.57", "@rolldown/binding-darwin-arm64": "1.0.0-beta.57", "@rolldown/binding-darwin-x64": "1.0.0-beta.57", "@rolldown/binding-freebsd-x64": "1.0.0-beta.57", "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-beta.57", "@rolldown/binding-linux-arm64-gnu": "1.0.0-beta.57", "@rolldown/binding-linux-arm64-musl": "1.0.0-beta.57", "@rolldown/binding-linux-x64-gnu": "1.0.0-beta.57", "@rolldown/binding-linux-x64-musl": "1.0.0-beta.57", "@rolldown/binding-openharmony-arm64": "1.0.0-beta.57", "@rolldown/binding-wasm32-wasi": "1.0.0-beta.57", "@rolldown/binding-win32-arm64-msvc": "1.0.0-beta.57", "@rolldown/binding-win32-x64-msvc": "1.0.0-beta.57" }, "bin": { "rolldown": "bin/cli.mjs" } }, "sha512-lMMxcNN71GMsSko8RyeTaFoATHkCh4IWU7pYF73ziMYjhHZWfVesC6GQ+iaJCvZmVjvgSks9Ks1aaqEkBd8udg=="],
 
-    "rolldown-plugin-dts": ["rolldown-plugin-dts@0.17.7", "", { "dependencies": { "@babel/generator": "^7.28.5", "@babel/parser": "^7.28.5", "@babel/types": "^7.28.5", "ast-kit": "^2.2.0", "birpc": "^2.8.0", "dts-resolver": "^2.1.3", "get-tsconfig": "^4.13.0", "magic-string": "^0.30.21", "obug": "^1.0.0" }, "peerDependencies": { "@ts-macro/tsc": "^0.3.6", "@typescript/native-preview": ">=7.0.0-dev.20250601.1", "rolldown": "^1.0.0-beta.44", "typescript": "^5.0.0", "vue-tsc": "~3.1.0" }, "optionalPeers": ["@ts-macro/tsc", "@typescript/native-preview", "typescript", "vue-tsc"] }, "sha512-ZGgXMhzCItmznNzbJlTcC/KdM6bIwcZoYUykJ2q14HOGvnMhnl2RXU+XrIrdjA2Hyzq3nWqDH7qWaM5a4uCVnw=="],
+    "rolldown-plugin-dts": ["rolldown-plugin-dts@0.20.0", "", { "dependencies": { "@babel/generator": "^7.28.5", "@babel/parser": "^7.28.5", "@babel/types": "^7.28.5", "ast-kit": "^2.2.0", "birpc": "^4.0.0", "dts-resolver": "^2.1.3", "get-tsconfig": "^4.13.0", "obug": "^2.1.1" }, "peerDependencies": { "@ts-macro/tsc": "^0.3.6", "@typescript/native-preview": ">=7.0.0-dev.20250601.1", "rolldown": "^1.0.0-beta.57", "typescript": "^5.0.0", "vue-tsc": "~3.2.0" }, "optionalPeers": ["@ts-macro/tsc", "@typescript/native-preview", "typescript", "vue-tsc"] }, "sha512-cLAY1kN2ilTYMfZcFlGWbXnu6Nb+8uwUBsi+Mjbh4uIx7IN8uMOmJ7RxrrRgPsO4H7eSz3E+JwGoL1gyugiyUA=="],
 
     "safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
 
@@ -606,7 +594,7 @@
 
     "tree-kill": ["tree-kill@1.2.2", "", { "bin": { "tree-kill": "cli.js" } }, "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A=="],
 
-    "tsdown": ["tsdown@0.16.5", "", { "dependencies": { "ansis": "^4.2.0", "cac": "^6.7.14", "chokidar": "^4.0.3", "diff": "^8.0.2", "empathic": "^2.0.0", "hookable": "^5.5.3", "obug": "^2.0.0", "rolldown": "1.0.0-beta.50", "rolldown-plugin-dts": "^0.17.7", "semver": "^7.7.3", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tree-kill": "^1.2.2", "unconfig-core": "^7.4.1", "unrun": "^0.2.10" }, "peerDependencies": { "@arethetypeswrong/core": "^0.18.1", "@vitejs/devtools": "^0.0.0-alpha.17", "publint": "^0.3.0", "typescript": "^5.0.0", "unplugin-lightningcss": "^0.4.0", "unplugin-unused": "^0.5.0" }, "optionalPeers": ["@arethetypeswrong/core", "@vitejs/devtools", "publint", "typescript", "unplugin-lightningcss", "unplugin-unused"], "bin": { "tsdown": "dist/run.mjs" } }, "sha512-jo/2MmJI1uNJ+QvwEfF/2DcICd2Bc/Gc/XIVJS9Gvfns7ji5TgUeu3kYfG8nA/mGgWXU8REpTNweIcVJQoSLAQ=="],
+    "tsdown": ["tsdown@0.18.3", "", { "dependencies": { "ansis": "^4.2.0", "cac": "^6.7.14", "defu": "^6.1.4", "empathic": "^2.0.0", "hookable": "^6.0.1", "import-without-cache": "^0.2.5", "obug": "^2.1.1", "picomatch": "^4.0.3", "rolldown": "1.0.0-beta.57", "rolldown-plugin-dts": "^0.20.0", "semver": "^7.7.3", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tree-kill": "^1.2.2", "unconfig-core": "^7.4.2", "unrun": "^0.2.21" }, "peerDependencies": { "@arethetypeswrong/core": "^0.18.1", "@vitejs/devtools": "*", "publint": "^0.3.0", "typescript": "^5.0.0", "unplugin-lightningcss": "^0.4.0", "unplugin-unused": "^0.5.0" }, "optionalPeers": ["@arethetypeswrong/core", "@vitejs/devtools", "publint", "typescript", "unplugin-lightningcss", "unplugin-unused"], "bin": { "tsdown": "dist/run.mjs" } }, "sha512-OVFzktKDTglFAUh/WO8WamBUbZoBlJ9m7NgZZrVyIKe32BfXBeRZ+soFFpuOGVP8g8OU4tOLOpTyPTELWvcTFw=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
@@ -618,7 +606,7 @@
 
     "uglify-js": ["uglify-js@3.19.3", "", { "bin": { "uglifyjs": "bin/uglifyjs" } }, "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ=="],
 
-    "unconfig-core": ["unconfig-core@7.4.1", "", { "dependencies": { "@quansync/fs": "^0.1.5", "quansync": "^0.2.11" } }, "sha512-Bp/bPZjV2Vl/fofoA2OYLSnw1Z0MOhCX7zHnVCYrazpfZvseBbGhwcNQMxsg185Mqh7VZQqK3C8hFG/Dyng+yA=="],
+    "unconfig-core": ["unconfig-core@7.4.2", "", { "dependencies": { "@quansync/fs": "^1.0.0", "quansync": "^1.0.0" } }, "sha512-VgPCvLWugINbXvMQDf8Jh0mlbvNjNC6eSUziHsBCMpxR05OPrNrvDnyatdMjRgcHaaNsCqz+wjNXxNw1kRLHUg=="],
 
     "undici": ["undici@7.16.0", "", {}, "sha512-QEg3HPMll0o3t2ourKwOeUAZ159Kn9mx5pnzHRQO8+Wixmh88YdZRiIwat0iNzNNXn0yoEtXJqFpyW7eM8BV7g=="],
 
@@ -634,7 +622,7 @@
 
     "universalify": ["universalify@2.0.1", "", {}, "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="],
 
-    "unrun": ["unrun@0.2.10", "", { "dependencies": { "@oxc-project/runtime": "^0.97.0", "rolldown": "1.0.0-beta.50" }, "peerDependencies": { "synckit": "^0.11.11" }, "optionalPeers": ["synckit"], "bin": { "unrun": "dist/cli.mjs" } }, "sha512-IcQCpGp3oawzr2ANNmMCh2XNssrDueQvoOfC/ranG4Enq0vVCCLfen+sJTaLYKR22vxZttF2KvvaubgbUadTqA=="],
+    "unrun": ["unrun@0.2.21", "", { "dependencies": { "rolldown": "1.0.0-beta.57" }, "peerDependencies": { "synckit": "^0.11.11" }, "optionalPeers": ["synckit"], "bin": { "unrun": "dist/cli.mjs" } }, "sha512-VuwI4YKtwBpDvM7hCEop2Im/ezS82dliqJpkh9pvS6ve8HcUsBDvESHxMmUfImXR03GkmfdDynyrh/pUJnlguw=="],
 
     "url-join": ["url-join@5.0.0", "", {}, "sha512-n2huDr9h9yzd6exQVnH/jU5mr+Pfx08LRXXZhkLLetAMESRj+anQsTAh940iMrIetKAmry9coFuZQ2jY8/p3WA=="],
 
@@ -688,13 +676,13 @@
 
     "env-ci/execa": ["execa@8.0.1", "", { "dependencies": { "cross-spawn": "^7.0.3", "get-stream": "^8.0.1", "human-signals": "^5.0.0", "is-stream": "^3.0.0", "merge-stream": "^2.0.0", "npm-run-path": "^5.1.0", "onetime": "^6.0.0", "signal-exit": "^4.1.0", "strip-final-newline": "^3.0.0" } }, "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg=="],
 
-    "fdir/picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
-
     "import-fresh/resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
 
     "load-json-file/parse-json": ["parse-json@4.0.0", "", { "dependencies": { "error-ex": "^1.3.1", "json-parse-better-errors": "^1.0.1" } }, "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw=="],
 
     "make-asynchronous/type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
+
+    "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
     "npm/@isaacs/balanced-match": ["@isaacs/balanced-match@4.0.1", "", {}, "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ=="],
 
@@ -1048,8 +1036,6 @@
 
     "read-pkg/parse-json": ["parse-json@8.3.0", "", { "dependencies": { "@babel/code-frame": "^7.26.2", "index-to-position": "^1.1.0", "type-fest": "^4.39.1" } }, "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ=="],
 
-    "rolldown-plugin-dts/obug": ["obug@1.0.0", "", { "peerDependencies": { "ms": "^2.0.0" }, "optionalPeers": ["ms"] }, "sha512-WKcS43Yl6YPJekid7KiRdT6CHMSmYWVfJiSFbTaGxWQlC+cEBPxHa9jR1uS2cMiQmXd8Hsa2ipAKErQ/GLhSpg=="],
-
     "semantic-release/@semantic-release/error": ["@semantic-release/error@4.0.0", "", {}, "sha512-mgdxrHTLOjOddRVYIYDo0fR3/v61GNN1YGkfbrjuIKg/uMgCd+Qzo3UAXJ+woLQQpos4pl5Esuw5A7AoNlzjUQ=="],
 
     "semantic-release/aggregate-error": ["aggregate-error@5.0.0", "", { "dependencies": { "clean-stack": "^5.2.0", "indent-string": "^5.0.0" } }, "sha512-gOsf2YwSlleG6IjRYG2A7k0HmBMEo6qVNk9Bp/EaLgAJT5ngH6PXbqa4ItvnEwCm/velL5jAnQgsHsWnjhGmvw=="],
@@ -1065,8 +1051,6 @@
     "tempy/is-stream": ["is-stream@3.0.0", "", {}, "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA=="],
 
     "tempy/type-fest": ["type-fest@2.19.0", "", {}, "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="],
-
-    "tinyglobby/picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
 
     "wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 

--- a/package.json
+++ b/package.json
@@ -5,23 +5,27 @@
     },
     "description": "JavaScript SDK for accessing ketabonline.com books",
     "devDependencies": {
-        "@biomejs/biome": "^2.3.6",
+        "@biomejs/biome": "^2.3.10",
         "@semantic-release/changelog": "^6.0.3",
         "@semantic-release/git": "^10.0.1",
-        "@types/bun": "^1.3.2",
-        "@types/node": "^24.10.1",
+        "@types/bun": "^1.3.5",
+        "@types/node": "^25.0.3",
         "semantic-release": "^25.0.2",
-        "tsdown": "^0.16.5",
+        "tsdown": "^0.18.3",
         "typescript": "^5.9.3"
     },
     "engines": {
-        "bun": ">=1.3.2",
+        "bun": ">=1.3.5",
         "node": ">=24.0.0"
     },
     "exports": {
         ".": {
             "default": "./dist/index.mjs",
             "types": "./dist/index.d.mts"
+        },
+        "./node": {
+            "default": "./dist/node.mjs",
+            "types": "./dist/node.d.mts"
         },
         "./package.json": "./package.json"
     },
@@ -38,7 +42,7 @@
     "license": "MIT",
     "main": "dist/index.mjs",
     "name": "ketab-online-sdk",
-    "packageManager": "bun@1.3.2",
+    "packageManager": "bun@1.3.5",
     "private": false,
     "repository": {
         "type": "git",
@@ -54,5 +58,5 @@
     "source": "src/index.ts",
     "type": "module",
     "types": "dist/index.d.mts",
-    "version": "1.2.0"
+    "version": "1.3.0"
 }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,10 +1,11 @@
 import { beforeEach, describe, expect, it, mock } from 'bun:test';
 
-const unzipFromUrlMock = mock();
+const downloadBookContentsMock = mock();
 const httpsGetMock = mock();
 
-mock.module('./utils/io', () => ({
-    unzipFromUrl: unzipFromUrlMock,
+// Mock the dedicated book module (avoids interference with io.test.ts)
+mock.module('./utils/book', () => ({
+    downloadBookContents: downloadBookContentsMock,
 }));
 
 mock.module('./utils/network', () => ({
@@ -33,7 +34,7 @@ const {
 describe('index exports', () => {
     beforeEach(() => {
         httpsGetMock.mockReset();
-        unzipFromUrlMock.mockReset();
+        downloadBookContentsMock.mockReset();
 
         // Default mock: return 404 response for httpsGet
         httpsGetMock.mockResolvedValue({ code: 404 });
@@ -70,7 +71,7 @@ describe('index exports', () => {
 
     it('should return parsed JSON book contents', async () => {
         const contents = { sections: [{ title: 'Section' }] };
-        unzipFromUrlMock.mockResolvedValue([
+        downloadBookContentsMock.mockResolvedValue([
             { data: new TextEncoder().encode(JSON.stringify(contents)), name: 'book.json' },
         ]);
 
@@ -80,7 +81,7 @@ describe('index exports', () => {
     });
 
     it('should throw when no JSON file found in book contents', async () => {
-        unzipFromUrlMock.mockResolvedValue([{ data: new Uint8Array(), name: 'other.txt' }]);
+        downloadBookContentsMock.mockResolvedValue([{ data: new Uint8Array(), name: 'other.txt' }]);
 
         await expect(getBookContents(12)).rejects.toThrow('No JSON file found in downloaded archive');
     });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -8,6 +8,9 @@ mock.module('./utils/io', () => ({
 }));
 
 mock.module('./utils/network', () => ({
+    API_BASE_URL: 'https://backend.ketabonline.com/api/v2',
+    apiUrl: (path: string) => `https://backend.ketabonline.com/api/v2${path}`,
+    BOOKS_CDN_URL: 'https://s2.ketabonline.com/books',
     buildUrl: (endpoint: string, params: Record<string, string | number>) => {
         const url = new URL(endpoint);
         Object.entries(params).forEach(([key, value]) => url.searchParams.append(key, value.toString()));

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -31,18 +31,12 @@ const {
 } = await import('./index');
 
 describe('index exports', () => {
-    const jsonData = { foo: 'bar' };
-
     beforeEach(() => {
         httpsGetMock.mockReset();
         unzipFromUrlMock.mockReset();
 
-        // Default mock: return 404 response
+        // Default mock: return 404 response for httpsGet
         httpsGetMock.mockResolvedValue({ code: 404 });
-
-        unzipFromUrlMock.mockResolvedValue([
-            { data: new TextEncoder().encode(JSON.stringify(jsonData)), name: 'book.json' },
-        ]);
     });
 
     it('should return author data when response code is 200', async () => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -29,7 +29,7 @@ const {
     getBooks,
     getCategories,
     getCategoryInfo,
-} = await import('./index');
+} = await import(`./index?t=${Date.now()}`);
 
 describe('index exports', () => {
     beforeEach(() => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,9 +9,9 @@ import type {
     CategoryInfo,
     RequestOptions,
 } from './types';
+import { downloadBookContents } from './utils/book';
 import { removeFalsyValues } from './utils/common';
-import { unzipFromUrl } from './utils/io';
-import { apiUrl, BOOKS_CDN_URL, buildUrl, httpsGet } from './utils/network';
+import { apiUrl, buildUrl, httpsGet } from './utils/network';
 
 // Re-export types for consumers
 export type { IndexItem, Page } from './types';
@@ -40,17 +40,6 @@ export {
     stripFootnoteLinks,
     stripHtmlTags,
 } from './utils/content';
-
-/**
- * Downloads and parses the book contents for a given book ID.
- *
- * @param id - The ID of the book to download.
- * @returns A promise that resolves with the extracted entries.
- */
-const downloadBookContents = async (id: number) => {
-    const entries = await unzipFromUrl(`${BOOKS_CDN_URL}/${id}/${id}.data.zip`);
-    return entries;
-};
 
 /**
  * Retrieves information about the author with the given ID.

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,8 +44,8 @@ export {
 /**
  * Downloads and parses the book contents for a given book ID.
  *
- * @param {number} id - The ID of the book to download.
- * @returns {Promise<UnzippedEntry[]>} A promise that resolves with the extracted entries.
+ * @param id - The ID of the book to download.
+ * @returns A promise that resolves with the extracted entries.
  */
 const downloadBookContents = async (id: number) => {
     const entries = await unzipFromUrl(`${BOOKS_CDN_URL}/${id}/${id}.data.zip`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,3 @@
-import fs from 'node:fs/promises';
-
 import type {
     ApiResponse,
     AuthorInfo,
@@ -12,44 +10,46 @@ import type {
     RequestOptions,
 } from './types';
 import { removeFalsyValues } from './utils/common';
-import { createTempDir, unzipFromUrl } from './utils/io';
-import { buildUrl, httpsGet } from './utils/network';
+import { unzipFromUrl } from './utils/io';
+import { apiUrl, BOOKS_CDN_URL, buildUrl, httpsGet } from './utils/network';
+
+// Re-export types for consumers
+export type { IndexItem, Page } from './types';
+export type { Footnote } from './utils/content';
+
+// Re-export content utilities
+export {
+    extractFootnotes,
+    extractPageText,
+    findIndexEntry,
+    flattenIndex,
+    getIndexBreadcrumb,
+    getPageByNumber,
+    getPagesByPart,
+    getPagesForIndex,
+    hasFootnotes,
+    htmlToMarkdown,
+    indexToMarkdown,
+    isHeaderParagraph,
+    normalizeLineEndings,
+    pagesToMarkdown,
+    pageToMarkdown,
+    pageToMarkdownWithFootnotes,
+    removeFootnoteReferences,
+    splitPageFootnotes,
+    stripFootnoteLinks,
+    stripHtmlTags,
+} from './utils/content';
 
 /**
- * Downloads the book contents for a given book ID and returns the extracted entries.
+ * Downloads and parses the book contents for a given book ID.
  *
  * @param {number} id - The ID of the book to download.
- * @returns {Promise<{ entries: UnzippedEntry[], outputDir: string }>} A promise that resolves with the entries and output directory.
+ * @returns {Promise<UnzippedEntry[]>} A promise that resolves with the extracted entries.
  */
 const downloadBookContents = async (id: number) => {
-    const outputDir = await createTempDir('ketabonline.com');
-    const entries = await unzipFromUrl(`https://s2.ketabonline.com/books/${id}/${id}.data.zip`);
-
-    return { entries, outputDir };
-};
-
-/**
- * Downloads the book with the given ID and saves it to the specified output file.
- *
- * @param {number} id - The ID of the book to download.
- * @param {string} outputFile - The path where the book should be saved.
- * @returns {Promise<string>} A promise that resolves with the path to the output file.
- */
-export const downloadBook = async (id: number, outputFile: string): Promise<string> => {
-    const { entries, outputDir } = await downloadBookContents(id);
-    const jsonEntry = entries.find((e) => e.name.endsWith('.json'));
-
-    if (!jsonEntry) {
-        await fs.rm(outputDir, { recursive: true });
-        throw new Error('No JSON file found in downloaded archive');
-    }
-
-    try {
-        await fs.writeFile(outputFile, jsonEntry.data);
-        return outputFile;
-    } finally {
-        await fs.rm(outputDir, { recursive: true });
-    }
+    const entries = await unzipFromUrl(`${BOOKS_CDN_URL}/${id}/${id}.data.zip`);
+    return entries;
 };
 
 /**
@@ -60,7 +60,7 @@ export const downloadBook = async (id: number, outputFile: string): Promise<stri
  * @throws Will throw an error if the author is not found or an unknown error occurs.
  */
 export const getAuthorInfo = async (id: number): Promise<AuthorInfo> => {
-    const response: ApiResponse = await httpsGet<ApiResponse>(`https://backend.ketabonline.com/api/v2/authors/${id}`);
+    const response: ApiResponse = await httpsGet<ApiResponse>(apiUrl(`authors/${id}`));
 
     if (response.code === 404) {
         throw new Error(`Author ${id} not found`);
@@ -80,7 +80,7 @@ export const getAuthorInfo = async (id: number): Promise<AuthorInfo> => {
  * @returns A promise that resolves with the matching authors.
  */
 export const getAuthors = async ({ query, ...options }: RequestOptions = {}): Promise<AuthorInfo[]> => {
-    const url = buildUrl(`https://backend.ketabonline.com/api/v2/authors`, {
+    const url = buildUrl(apiUrl('authors'), {
         ...options,
         ...(query && { q: query }),
     });
@@ -101,20 +101,15 @@ export const getAuthors = async ({ query, ...options }: RequestOptions = {}): Pr
  * @returns {Promise<BookContents>} A promise that resolves with the book contents.
  */
 export const getBookContents = async (id: number): Promise<BookContents> => {
-    const { entries, outputDir } = await downloadBookContents(id);
+    const entries = await downloadBookContents(id);
     const jsonEntry = entries.find((e) => e.name.endsWith('.json'));
 
     if (!jsonEntry) {
-        await fs.rm(outputDir, { recursive: true });
         throw new Error('No JSON file found in downloaded archive');
     }
 
-    try {
-        const data = JSON.parse(new TextDecoder().decode(jsonEntry.data)) as BookContents;
-        return data;
-    } finally {
-        await fs.rm(outputDir, { recursive: true });
-    }
+    const data = JSON.parse(new TextDecoder().decode(jsonEntry.data)) as BookContents;
+    return data;
 };
 
 /**
@@ -137,7 +132,7 @@ export const getBookIndex = async (
     id: number,
     { isRecursive = false, part = 1 }: BookIndexOptions = {},
 ): Promise<BookIndexEntry[]> => {
-    const url = buildUrl(`https://backend.ketabonline.com/api/v2/books/${id}/index`, {
+    const url = buildUrl(apiUrl(`books/${id}/index`), {
         is_recursive: isRecursive ? 1 : 0,
         part,
     });
@@ -163,7 +158,7 @@ export const getBookIndex = async (
  * @throws Will throw an error if the book is not found or an unknown error occurs.
  */
 export const getBookInfo = async (id: number): Promise<BookInfo> => {
-    const response: ApiResponse = await httpsGet<ApiResponse>(`https://backend.ketabonline.com/api/v2/books/${id}`);
+    const response: ApiResponse = await httpsGet<ApiResponse>(apiUrl(`books/${id}`));
 
     if (response.code === 404) {
         throw new Error(`Book ${id} not found`);
@@ -183,7 +178,7 @@ export const getBookInfo = async (id: number): Promise<BookInfo> => {
  * @returns A promise that resolves with the matching books.
  */
 export const getBooks = async ({ query, ...options }: RequestOptions = {}): Promise<BookInfo[]> => {
-    const url = buildUrl(`https://backend.ketabonline.com/api/v2/books`, { ...options, ...(query && { q: query }) });
+    const url = buildUrl(apiUrl('books'), { ...options, ...(query && { q: query }) });
     const response: ApiResponse = await httpsGet<ApiResponse>(url);
 
     if (response.code === 200) {
@@ -201,7 +196,7 @@ export const getBooks = async ({ query, ...options }: RequestOptions = {}): Prom
  * @returns A promise that resolves with the matching categories.
  */
 export const getCategories = async ({ query, ...options }: RequestOptions = {}): Promise<CategoryInfo[]> => {
-    const url = buildUrl(`https://backend.ketabonline.com/api/v2/categories`, {
+    const url = buildUrl(apiUrl('categories'), {
         ...options,
         ...(query && { q: query }),
     });
@@ -223,9 +218,7 @@ export const getCategories = async ({ query, ...options }: RequestOptions = {}):
  * @throws Will throw an error if the category is not found or an unknown error occurs.
  */
 export const getCategoryInfo = async (id: number): Promise<CategoryInfo> => {
-    const response: ApiResponse = await httpsGet<ApiResponse>(
-        `https://backend.ketabonline.com/api/v2/categories/${id}`,
-    );
+    const response: ApiResponse = await httpsGet<ApiResponse>(apiUrl(`categories/${id}`));
 
     if (response.code === 404) {
         throw new Error(`Category ${id} not found`);

--- a/src/node.test.ts
+++ b/src/node.test.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it, mock } from 'bun:test';
+
+const writeFileMock = mock();
+const getBookContentsMock = mock();
+
+mock.module('node:fs/promises', () => ({
+    default: {
+        writeFile: writeFileMock,
+    },
+    writeFile: writeFileMock,
+}));
+
+mock.module('./index', () => ({
+    getBookContents: getBookContentsMock,
+}));
+
+const { downloadBook } = await import('./node');
+
+describe('node exports', () => {
+    const jsonData = { foo: 'bar' };
+
+    beforeEach(() => {
+        writeFileMock.mockReset();
+        getBookContentsMock.mockReset();
+
+        getBookContentsMock.mockResolvedValue(jsonData);
+        writeFileMock.mockResolvedValue(undefined);
+    });
+
+    describe('downloadBook', () => {
+        it('should write downloaded JSON to destination', async () => {
+            const destination = '/books/book.json';
+
+            const result = await downloadBook(12, destination);
+
+            expect(getBookContentsMock).toHaveBeenCalledWith(12);
+            expect(writeFileMock).toHaveBeenCalledWith(destination, JSON.stringify(jsonData));
+            expect(result).toBe(destination);
+        });
+
+        it('should propagate errors from getBookContents', async () => {
+            getBookContentsMock.mockRejectedValue(new Error('Book not found'));
+
+            await expect(downloadBook(999, '/books/book.json')).rejects.toThrow('Book not found');
+        });
+
+        it('should propagate errors from writeFile', async () => {
+            writeFileMock.mockRejectedValue(new Error('Permission denied'));
+
+            await expect(downloadBook(12, '/books/book.json')).rejects.toThrow('Permission denied');
+        });
+    });
+});

--- a/src/node.ts
+++ b/src/node.ts
@@ -1,0 +1,25 @@
+/**
+ * Node.js-specific exports for ketab-online-sdk.
+ * These functions require Node.js filesystem APIs and will not work in browsers.
+ *
+ * @module ketab-online-sdk/node
+ */
+import fs from 'node:fs/promises';
+import { getBookContents } from './index';
+
+// Re-export everything from the main entry for convenience
+export * from './index';
+
+/**
+ * Downloads the book with the given ID and saves it to the specified output file.
+ * This function requires Node.js filesystem APIs and will not work in browsers.
+ *
+ * @param {number} id - The ID of the book to download.
+ * @param {string} outputFile - The path where the book should be saved.
+ * @returns {Promise<string>} A promise that resolves with the path to the output file.
+ */
+export const downloadBook = async (id: number, outputFile: string): Promise<string> => {
+    const contents = await getBookContents(id);
+    await fs.writeFile(outputFile, JSON.stringify(contents));
+    return outputFile;
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -369,7 +369,7 @@ type Hadeeth = {
 /**
  * Table of contents entry for a book.
  */
-type IndexItem = {
+export type IndexItem = {
     /** Child index entries (nested structure) */
     children?: IndexItem[];
     /** Unique identifier for the index entry */

--- a/src/utils/book.test.ts
+++ b/src/utils/book.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it, mock } from 'bun:test';
+
+const unzipFromUrlMock = mock();
+
+mock.module('./io', () => ({
+    unzipFromUrl: unzipFromUrlMock,
+}));
+
+mock.module('./network', () => ({
+    BOOKS_CDN_URL: 'https://s2.ketabonline.com/books',
+}));
+
+// Import with cache busting
+const { downloadBookContents } = await import(`./book?t=${Date.now()}`);
+
+describe('book utilities', () => {
+    it('should download and unzip book contents', async () => {
+        const mockEntries = [{ data: new Uint8Array(), name: 'book.json' }];
+        unzipFromUrlMock.mockResolvedValue(mockEntries);
+
+        const result = await downloadBookContents(123);
+
+        expect(unzipFromUrlMock).toHaveBeenCalledWith('https://s2.ketabonline.com/books/123/123.data.zip');
+        expect(result).toBe(mockEntries);
+    });
+});

--- a/src/utils/book.ts
+++ b/src/utils/book.ts
@@ -1,0 +1,13 @@
+import { type UnzippedEntry, unzipFromUrl } from './io';
+import { BOOKS_CDN_URL } from './network';
+
+/**
+ * Downloads the raw book content entries for a given book ID.
+ *
+ * @param id - The ID of the book to download.
+ * @returns A promise that resolves with the extracted entries.
+ */
+export const downloadBookContents = async (id: number): Promise<UnzippedEntry[]> => {
+    const entries = await unzipFromUrl(`${BOOKS_CDN_URL}/${id}/${id}.data.zip`);
+    return entries;
+};

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -7,31 +7,26 @@
 const cleanObject = (obj: Record<string, any>): Record<string, any> => {
     const newObj: Record<string, any> = {};
 
-    for (const key in obj) {
-        if (obj[key]) {
-            const value = obj[key];
+    for (const [key, value] of Object.entries(obj)) {
+        if (!value) {
+            continue;
+        }
 
-            // Check for falsy values
-            if (value) {
-                // Handle nested objects
-                if (typeof value === 'object' && !Array.isArray(value)) {
-                    const cleanedValue = cleanObject(value);
-                    if (Object.keys(cleanedValue).length > 0) {
-                        newObj[key] = cleanedValue;
-                    }
-                }
-                // Handle arrays
-                else if (Array.isArray(value)) {
-                    const cleanedArray = value
-                        .map((item) => (typeof item === 'object' ? cleanObject(item) : item))
-                        .filter((item) => item); // Filter out falsy items
-                    if (cleanedArray.length > 0) {
-                        newObj[key] = cleanedArray;
-                    }
-                } else {
-                    newObj[key] = value;
-                }
+        if (Array.isArray(value)) {
+            const cleanedArray = value
+                .map((item) => (typeof item === 'object' && item !== null ? cleanObject(item) : item))
+                .filter(Boolean);
+
+            if (cleanedArray.length > 0) {
+                newObj[key] = cleanedArray;
             }
+        } else if (typeof value === 'object') {
+            const cleanedValue = cleanObject(value);
+            if (Object.keys(cleanedValue).length > 0) {
+                newObj[key] = cleanedValue;
+            }
+        } else {
+            newObj[key] = value;
         }
     }
 

--- a/src/utils/content.test.ts
+++ b/src/utils/content.test.ts
@@ -338,6 +338,48 @@ describe('content utilities', () => {
             },
         ];
 
+        // Deeply nested mock index (3+ levels) for testing recursive traversal
+        const deeplyNestedIndex: IndexItem[] = [
+            {
+                children: [
+                    {
+                        children: [
+                            {
+                                children: [
+                                    {
+                                        id: 4,
+                                        page: 40,
+                                        page_id: 40,
+                                        part_name: '1',
+                                        title: 'Level 4 Item',
+                                        title_level: 4,
+                                    },
+                                ],
+                                id: 3,
+                                page: 30,
+                                page_id: 30,
+                                part_name: '1',
+                                title: 'Level 3 Item',
+                                title_level: 3,
+                            },
+                        ],
+                        id: 2,
+                        page: 20,
+                        page_id: 20,
+                        part_name: '1',
+                        title: 'Level 2 Item',
+                        title_level: 2,
+                    },
+                ],
+                id: 1,
+                page: 10,
+                page_id: 10,
+                part_name: '1',
+                title: 'Level 1 Item',
+                title_level: 1,
+            },
+        ];
+
         describe('flattenIndex', () => {
             it('should flatten hierarchical index', () => {
                 const flat = flattenIndex(mockIndex);
@@ -347,6 +389,13 @@ describe('content utilities', () => {
 
             it('should handle empty index', () => {
                 expect(flattenIndex([])).toHaveLength(0);
+            });
+
+            it('should flatten deeply nested index (3+ levels)', () => {
+                const flat = flattenIndex(deeplyNestedIndex);
+                expect(flat).toHaveLength(4);
+                expect(flat.map((i) => i.id)).toEqual([1, 2, 3, 4]);
+                expect(flat.map((i) => i.title_level)).toEqual([1, 2, 3, 4]);
             });
         });
 
@@ -363,6 +412,12 @@ describe('content utilities', () => {
 
             it('should return undefined for non-existent entry', () => {
                 expect(findIndexEntry(mockIndex, 999)).toBeUndefined();
+            });
+
+            it('should find deeply nested entry (level 4)', () => {
+                const entry = findIndexEntry(deeplyNestedIndex, 4);
+                expect(entry?.title).toBe('Level 4 Item');
+                expect(entry?.title_level).toBe(4);
             });
         });
 
@@ -381,6 +436,17 @@ describe('content utilities', () => {
 
             it('should return empty array for non-existent entry', () => {
                 expect(getIndexBreadcrumb(mockIndex, 999)).toHaveLength(0);
+            });
+
+            it('should build breadcrumb for deeply nested entry (level 4)', () => {
+                const breadcrumb = getIndexBreadcrumb(deeplyNestedIndex, 4);
+                expect(breadcrumb).toHaveLength(4);
+                expect(breadcrumb.map((i) => i.title)).toEqual([
+                    'Level 1 Item',
+                    'Level 2 Item',
+                    'Level 3 Item',
+                    'Level 4 Item',
+                ]);
             });
         });
 

--- a/src/utils/content.test.ts
+++ b/src/utils/content.test.ts
@@ -1,0 +1,512 @@
+import { describe, expect, it } from 'bun:test';
+import type { IndexItem, Page } from '../types';
+import {
+    extractFootnotes,
+    extractPageText,
+    findIndexEntry,
+    flattenIndex,
+    getIndexBreadcrumb,
+    getPageByNumber,
+    getPagesByPart,
+    getPagesForIndex,
+    hasFootnotes,
+    htmlToMarkdown,
+    indexToMarkdown,
+    isHeaderParagraph,
+    normalizeLineEndings,
+    pagesToMarkdown,
+    pageToMarkdown,
+    pageToMarkdownWithFootnotes,
+    removeFootnoteReferences,
+    splitPageFootnotes,
+    stripFootnoteLinks,
+    stripHtmlTags,
+} from './content';
+
+describe('content utilities', () => {
+    describe('normalizeLineEndings', () => {
+        it('should convert CRLF to LF', () => {
+            expect(normalizeLineEndings('line1\r\nline2')).toBe('line1\nline2');
+        });
+
+        it('should convert CR to LF', () => {
+            expect(normalizeLineEndings('line1\rline2')).toBe('line1\nline2');
+        });
+
+        it('should leave LF unchanged', () => {
+            expect(normalizeLineEndings('line1\nline2')).toBe('line1\nline2');
+        });
+
+        it('should handle mixed line endings', () => {
+            expect(normalizeLineEndings('a\r\nb\rc\nd')).toBe('a\nb\nc\nd');
+        });
+
+        it('should handle empty string', () => {
+            expect(normalizeLineEndings('')).toBe('');
+        });
+
+        it('should handle string without line endings', () => {
+            expect(normalizeLineEndings('no line breaks')).toBe('no line breaks');
+        });
+
+        it('should handle multiple consecutive Windows line endings', () => {
+            expect(normalizeLineEndings('a\r\n\r\nb')).toBe('a\n\nb');
+        });
+
+        it('should handle Arabic text with line endings', () => {
+            expect(normalizeLineEndings('بسم الله\r\nالرحمن الرحيم')).toBe('بسم الله\nالرحمن الرحيم');
+        });
+    });
+
+    describe('stripHtmlTags', () => {
+        it('should remove all HTML tags', () => {
+            expect(stripHtmlTags('<p>Hello <strong>world</strong></p>')).toBe('Hello world');
+        });
+
+        it('should handle empty input', () => {
+            expect(stripHtmlTags('')).toBe('');
+        });
+
+        it('should handle text without tags', () => {
+            expect(stripHtmlTags('plain text')).toBe('plain text');
+        });
+
+        it('should remove self-closing tags', () => {
+            expect(stripHtmlTags('Line 1<br/>Line 2')).toBe('Line 1Line 2');
+        });
+
+        it('should remove tags with attributes', () => {
+            expect(stripHtmlTags('<div class="test">Content</div>')).toBe('Content');
+        });
+
+        it('should remove nested tags', () => {
+            expect(stripHtmlTags('<div><span>Nested</span></div>')).toBe('Nested');
+        });
+
+        it('should handle multiple tags', () => {
+            expect(stripHtmlTags('<h1>Title</h1><p>Paragraph</p>')).toBe('TitleParagraph');
+        });
+
+        it('should handle Arabic text with HTML', () => {
+            expect(stripHtmlTags('<p>بسم الله</p>')).toBe('بسم الله');
+        });
+
+        it('should remove anchor tags', () => {
+            expect(stripHtmlTags('<a href="test">Link</a>')).toBe('Link');
+        });
+
+        it('should handle empty spans', () => {
+            expect(stripHtmlTags('Content<span id="link-123"></span>More')).toBe('ContentMore');
+        });
+    });
+
+    describe('isHeaderParagraph', () => {
+        it('should detect باب headers', () => {
+            expect(isHeaderParagraph('(قَوْلُهُ بَابُ إِذَا صَلَّى خَمْسًا)')).toBe(true);
+        });
+
+        it('should detect فصل headers', () => {
+            expect(isHeaderParagraph('(فصل في الصلاة)')).toBe(true);
+        });
+
+        it('should detect كتاب headers', () => {
+            expect(isHeaderParagraph('(كتاب الطهارة)')).toBe(true);
+        });
+
+        it('should detect قوله headers without diacritics', () => {
+            expect(isHeaderParagraph('(قوله باب الصلاة)')).toBe(true);
+        });
+
+        it('should not match regular text', () => {
+            expect(isHeaderParagraph('هذا نص عادي')).toBe(false);
+        });
+
+        it('should not match text without parentheses', () => {
+            expect(isHeaderParagraph('باب الصلاة')).toBe(false);
+        });
+
+        it('should not match parentheses without header markers', () => {
+            expect(isHeaderParagraph('(نص عادي)')).toBe(false);
+        });
+
+        it('should handle empty string', () => {
+            expect(isHeaderParagraph('')).toBe(false);
+        });
+    });
+
+    describe('htmlToMarkdown', () => {
+        it('should convert paragraphs to text with newlines', () => {
+            const html = '<p class="g-paragraph">First paragraph</p><p class="g-paragraph">Second paragraph</p>';
+            expect(htmlToMarkdown(html)).toBe('First paragraph\n\nSecond paragraph');
+        });
+
+        it('should convert header paragraphs to markdown headers', () => {
+            const html = '<p class="g-paragraph" id="p-1">(قَوْلُهُ بَابُ الصلاة)</p>';
+            expect(htmlToMarkdown(html)).toBe('## (قَوْلُهُ بَابُ الصلاة)');
+        });
+
+        it('should strip span tags but keep content', () => {
+            const html = '<p>Text with <span class="g-holy-word">الله</span> inside</p>';
+            expect(htmlToMarkdown(html)).toBe('Text with الله inside');
+        });
+
+        it('should handle empty input', () => {
+            expect(htmlToMarkdown('')).toBe('');
+        });
+
+        it('should handle nested HTML', () => {
+            const html = '<p class="g-paragraph">Text with <span class="g-square-brackets">[١٢٢٦]</span> reference</p>';
+            expect(htmlToMarkdown(html)).toBe('Text with [١٢٢٦] reference');
+        });
+
+        it('should handle text without any HTML tags', () => {
+            const input = 'Plain text without any tags';
+            expect(htmlToMarkdown(input)).toBe('Plain text without any tags');
+        });
+
+        it('should handle multiple paragraphs with mixed content', () => {
+            const html = `<p class="g-paragraph" id="p-1">(باب الصلاة)</p><p class="g-paragraph" id="p-2">حَدَّثَنَا أَبُو بَكْرٍ</p>`;
+            const result = htmlToMarkdown(html);
+            expect(result).toContain('## (باب الصلاة)');
+            expect(result).toContain('حَدَّثَنَا أَبُو بَكْرٍ');
+        });
+
+        it('should handle self-closing tags', () => {
+            const html = '<p>Text<br/>More text</p>';
+            expect(htmlToMarkdown(html)).toBe('TextMore text');
+        });
+
+        it('should handle complex real-world content', () => {
+            const html = `<p class="g-paragraph g-rtl" id="p-1">مُقَدّمَة</p><p class="g-paragraph g-rtl" id="p-2">قَالَ الشَّيْخ الإِمَام <span class="g-holy-word">تَعَالَى</span> فِي عشرَة فُصُول</p>`;
+            const result = htmlToMarkdown(html);
+            expect(result).toContain('مُقَدّمَة');
+            expect(result).toContain('تَعَالَى');
+            expect(result).toContain('فُصُول');
+        });
+
+        it('should handle Quranic text with brackets', () => {
+            const html = '<p>﴿فَمَنْ يَعْمَلْ مِثْقَالَ ذَرَّةٍ خَيْرًا يَرَهُ﴾</p>';
+            expect(htmlToMarkdown(html)).toBe('﴿فَمَنْ يَعْمَلْ مِثْقَالَ ذَرَّةٍ خَيْرًا يَرَهُ﴾');
+        });
+
+        it('should strip anchor tags but keep text', () => {
+            const html = '<p>Visit <a href="https://example.com">example</a> site</p>';
+            expect(htmlToMarkdown(html)).toBe('Visit example site');
+        });
+
+        it('should handle uppercase HTML tags', () => {
+            const html = '<P>Uppercase tags</P>';
+            expect(htmlToMarkdown(html)).toBe('Uppercase tags');
+        });
+    });
+
+    describe('page utilities', () => {
+        const mockPages: Page[] = [
+            {
+                content: '<p>Page one content</p>',
+                id: 1,
+                index: 100,
+                page: 3,
+                part: { id: 1, name: '1' },
+                quran: { from_aya_id: 0, sura_id: 0, to_aya_id: 0 },
+                reciters: [],
+                rowa: [],
+                seal: 'abc',
+                shrooh: [],
+            },
+            {
+                content: '<p>Page two content</p>',
+                id: 2,
+                index: 100,
+                page: 4,
+                part: { id: 1, name: '1' },
+                quran: { from_aya_id: 0, sura_id: 0, to_aya_id: 0 },
+                reciters: [],
+                rowa: [],
+                seal: 'def',
+                shrooh: [],
+            },
+            {
+                content: '<p>Page three content</p>',
+                id: 3,
+                index: 200,
+                page: 5,
+                part: { id: 2, name: '2' },
+                quran: { from_aya_id: 0, sura_id: 0, to_aya_id: 0 },
+                reciters: [],
+                rowa: [],
+                seal: 'ghi',
+                shrooh: [],
+            },
+        ];
+
+        describe('extractPageText', () => {
+            it('should extract plain text from page content', () => {
+                expect(extractPageText(mockPages[0]!)).toBe('Page one content');
+            });
+        });
+
+        describe('pageToMarkdown', () => {
+            it('should convert page content to markdown', () => {
+                expect(pageToMarkdown(mockPages[0]!)).toBe('Page one content');
+            });
+        });
+
+        describe('pagesToMarkdown', () => {
+            it('should combine multiple pages', () => {
+                const result = pagesToMarkdown(mockPages.slice(0, 2));
+                expect(result).toContain('Page one content');
+                expect(result).toContain('Page two content');
+            });
+
+            it('should include page numbers when requested', () => {
+                const result = pagesToMarkdown(mockPages.slice(0, 1), { includePageNumbers: true });
+                expect(result).toContain('<!-- Page 3, Part 1 -->');
+            });
+        });
+
+        describe('getPageByNumber', () => {
+            it('should find page by page number', () => {
+                const page = getPageByNumber(mockPages, 4);
+                expect(page?.id).toBe(2);
+            });
+
+            it('should return undefined for non-existent page', () => {
+                expect(getPageByNumber(mockPages, 999)).toBeUndefined();
+            });
+        });
+
+        describe('getPagesByPart', () => {
+            it('should filter pages by part name', () => {
+                const pages = getPagesByPart(mockPages, '1');
+                expect(pages).toHaveLength(2);
+            });
+
+            it('should return empty array for non-existent part', () => {
+                expect(getPagesByPart(mockPages, '99')).toHaveLength(0);
+            });
+        });
+
+        describe('getPagesForIndex', () => {
+            it('should filter pages by index ID', () => {
+                const pages = getPagesForIndex(mockPages, 100);
+                expect(pages).toHaveLength(2);
+            });
+
+            it('should return empty array for non-existent index', () => {
+                expect(getPagesForIndex(mockPages, 999)).toHaveLength(0);
+            });
+        });
+    });
+
+    describe('index utilities', () => {
+        const mockIndex: IndexItem[] = [
+            {
+                children: [
+                    {
+                        children: [],
+                        id: 2,
+                        page: 5,
+                        page_id: 5,
+                        part_name: '1',
+                        title: 'Section 1.1',
+                        title_level: 2,
+                    },
+                    {
+                        id: 3,
+                        page: 10,
+                        page_id: 10,
+                        part_name: '1',
+                        title: 'Section 1.2',
+                        title_level: 2,
+                    },
+                ],
+                id: 1,
+                page: 1,
+                page_id: 1,
+                part_name: '1',
+                title: 'Chapter 1',
+                title_level: 1,
+            },
+            {
+                id: 4,
+                page: 20,
+                page_id: 20,
+                part_name: '1',
+                title: 'Chapter 2',
+                title_level: 1,
+            },
+        ];
+
+        describe('flattenIndex', () => {
+            it('should flatten hierarchical index', () => {
+                const flat = flattenIndex(mockIndex);
+                expect(flat).toHaveLength(4);
+                expect(flat.map((i) => i.id)).toEqual([1, 2, 3, 4]);
+            });
+
+            it('should handle empty index', () => {
+                expect(flattenIndex([])).toHaveLength(0);
+            });
+        });
+
+        describe('findIndexEntry', () => {
+            it('should find top-level entry', () => {
+                const entry = findIndexEntry(mockIndex, 1);
+                expect(entry?.title).toBe('Chapter 1');
+            });
+
+            it('should find nested entry', () => {
+                const entry = findIndexEntry(mockIndex, 2);
+                expect(entry?.title).toBe('Section 1.1');
+            });
+
+            it('should return undefined for non-existent entry', () => {
+                expect(findIndexEntry(mockIndex, 999)).toBeUndefined();
+            });
+        });
+
+        describe('getIndexBreadcrumb', () => {
+            it('should build breadcrumb for nested entry', () => {
+                const breadcrumb = getIndexBreadcrumb(mockIndex, 2);
+                expect(breadcrumb).toHaveLength(2);
+                expect(breadcrumb[0]?.title).toBe('Chapter 1');
+                expect(breadcrumb[1]?.title).toBe('Section 1.1');
+            });
+
+            it('should return single item for top-level entry', () => {
+                const breadcrumb = getIndexBreadcrumb(mockIndex, 1);
+                expect(breadcrumb).toHaveLength(1);
+            });
+
+            it('should return empty array for non-existent entry', () => {
+                expect(getIndexBreadcrumb(mockIndex, 999)).toHaveLength(0);
+            });
+        });
+
+        describe('indexToMarkdown', () => {
+            it('should convert index to markdown TOC', () => {
+                const md = indexToMarkdown(mockIndex);
+                expect(md).toContain('## Chapter 1');
+                expect(md).toContain('- Section 1.1');
+                expect(md).toContain('## Chapter 2');
+            });
+
+            it('should respect maxDepth option', () => {
+                const md = indexToMarkdown(mockIndex, { maxDepth: 1 });
+                expect(md).toContain('## Chapter 1');
+                expect(md).not.toContain('Section 1.1');
+            });
+        });
+    });
+
+    describe('footnote utilities', () => {
+        // Sample HTML with footnotes from ketabonline
+        const sampleHtmlWithFootnotes = `<p class="g-paragraph g-rtl" id="p-1">وذكر الذهبي أن الدَّبَري عُمِّر دهرًا؛ فأكثر عنه الطبراني <span class="g-parentheses">  <a href="#foot-1" class="g-footnote-link">(١)</a> </span> .</p><p class="g-paragraph g-rtl" id="p-2">قال الذهبي في  <span class="g-quotes">"ميزان الاعتدال"</span> .</p><p class="g-paragraph g-ltr" id="p-3"><div class="g-page-separator" id="page-separator"></div><div class="g-page-footer"></p><p class="g-paragraph g-rtl" id="p-4"><span class="g-list"> <span id="foot-1" class="g-footnote-target">(١)</span> </span>   <span class="g-quotes">"تاريخ الإسلام"</span>  <span class="g-parentheses"> (٥/ ٣٧٨)</span> .</p>`;
+
+        const sampleHtmlWithoutFootnotes = `<p class="g-paragraph g-rtl" id="p-1">المُصَنَّفُ</p><p class="g-paragraph g-rtl" id="p-2">للإمام الحافظ أبى بكر عبد الرزاق</p>`;
+
+        describe('splitPageFootnotes', () => {
+            it('should split HTML at page footer', () => {
+                const [body, footer] = splitPageFootnotes(sampleHtmlWithFootnotes);
+                expect(body).toContain('الدَّبَري');
+                expect(body).not.toContain('g-page-footer');
+                expect(footer).toContain('g-page-footer');
+                expect(footer).toContain('foot-1');
+            });
+
+            it('should return full content as body when no footer', () => {
+                const [body, footer] = splitPageFootnotes(sampleHtmlWithoutFootnotes);
+                expect(body).toBe(sampleHtmlWithoutFootnotes);
+                expect(footer).toBe('');
+            });
+
+            it('should handle empty input', () => {
+                const [body, footer] = splitPageFootnotes('');
+                expect(body).toBe('');
+                expect(footer).toBe('');
+            });
+        });
+
+        describe('hasFootnotes', () => {
+            it('should return true when footnotes present', () => {
+                expect(hasFootnotes(sampleHtmlWithFootnotes)).toBe(true);
+            });
+
+            it('should return false when no footnotes', () => {
+                expect(hasFootnotes(sampleHtmlWithoutFootnotes)).toBe(false);
+            });
+        });
+
+        describe('stripFootnoteLinks', () => {
+            it('should remove footnote link tags but keep text', () => {
+                const html = 'Text <a href="#foot-1" class="g-footnote-link">(١)</a> more';
+                expect(stripFootnoteLinks(html)).toBe('Text (١) more');
+            });
+
+            it('should handle multiple footnote links', () => {
+                const html =
+                    'A <a href="#foot-1" class="g-footnote-link">(١)</a> B <a href="#foot-2" class="g-footnote-link">(٢)</a> C';
+                expect(stripFootnoteLinks(html)).toBe('A (١) B (٢) C');
+            });
+
+            it('should handle empty input', () => {
+                expect(stripFootnoteLinks('')).toBe('');
+            });
+        });
+
+        describe('removeFootnoteReferences', () => {
+            it('should remove footnote reference spans completely', () => {
+                const html =
+                    'Text <span class="g-parentheses"><a href="#foot-1" class="g-footnote-link">(١)</a></span> more';
+                expect(removeFootnoteReferences(html)).toBe('Text  more');
+            });
+
+            it('should handle empty input', () => {
+                expect(removeFootnoteReferences('')).toBe('');
+            });
+
+            it('should preserve non-footnote parentheses spans', () => {
+                const html = 'Text <span class="g-parentheses">(regular)</span> more';
+                expect(removeFootnoteReferences(html)).toBe(html);
+            });
+        });
+
+        describe('extractFootnotes', () => {
+            it('should extract footnotes from footer HTML', () => {
+                const [, footer] = splitPageFootnotes(sampleHtmlWithFootnotes);
+                const footnotes = extractFootnotes(footer);
+                expect(footnotes.length).toBeGreaterThan(0);
+                expect(footnotes[0]?.number).toBe(1);
+            });
+
+            it('should return empty array for empty input', () => {
+                expect(extractFootnotes('')).toHaveLength(0);
+            });
+
+            it('should return empty array when no footnote targets', () => {
+                expect(extractFootnotes('<p>Just some text</p>')).toHaveLength(0);
+            });
+        });
+
+        describe('pageToMarkdownWithFootnotes', () => {
+            it('should include footnotes by default', () => {
+                const md = pageToMarkdownWithFootnotes(sampleHtmlWithFootnotes);
+                expect(md).toContain('الدَّبَري');
+                expect(md).toContain('---');
+            });
+
+            it('should exclude footnotes when disabled', () => {
+                const md = pageToMarkdownWithFootnotes(sampleHtmlWithFootnotes, { includeFootnotes: false });
+                expect(md).toContain('الدَّبَري');
+                expect(md).not.toContain('[^1]');
+            });
+
+            it('should work with content without footnotes', () => {
+                const md = pageToMarkdownWithFootnotes(sampleHtmlWithoutFootnotes);
+                expect(md).toContain('المُصَنَّفُ');
+                expect(md).not.toContain('---');
+            });
+        });
+    });
+});

--- a/src/utils/content.ts
+++ b/src/utils/content.ts
@@ -255,17 +255,16 @@ export const indexToMarkdown = (index: IndexItem[], options: { maxDepth?: number
         }
 
         for (const item of items) {
-            const indent = '  '.repeat(depth - 1);
-            const prefix = depth === 1 ? '##' : '-';
             const pageInfo = item.part_name ? ` (Part ${item.part_name}, p. ${item.page})` : ` (p. ${item.page})`;
 
             if (depth === 1) {
-                lines.push(`${prefix} ${item.title}${pageInfo}`);
+                lines.push(`## ${item.title}${pageInfo}`);
             } else {
-                lines.push(`${indent}${prefix} ${item.title}${pageInfo}`);
+                const indent = '  '.repeat(depth - 1);
+                lines.push(`${indent}- ${item.title}${pageInfo}`);
             }
 
-            if (item.children && item.children.length > 0) {
+            if (item.children?.length) {
                 traverse(item.children, depth + 1);
             }
         }

--- a/src/utils/content.ts
+++ b/src/utils/content.ts
@@ -12,6 +12,8 @@ export const normalizeLineEndings = (text: string): string => {
 
 /**
  * Strips all HTML tags from content, keeping only text.
+ * Note: This uses a simple regex suitable for trusted ketabonline HTML.
+ * It is not a sanitizer for untrusted user input.
  *
  * @param html - HTML content
  * @returns Plain text content
@@ -401,8 +403,8 @@ export const extractFootnotes = (footerHtml: string): Footnote[] => {
     const footnoteRegex =
         /<span[^>]*id="foot-(\d+)"[^>]*class="g-footnote-target"[^>]*>\([^)]*\)<\/span>\s*([\s\S]*?)(?=<span[^>]*class="g-list"|<\/div>|$)/gi;
 
-    let match;
-    while ((match = footnoteRegex.exec(footerHtml)) !== null) {
+    const matches = footerHtml.matchAll(footnoteRegex);
+    for (const match of matches) {
         const number = parseInt(match[1]!, 10);
         const rawText = match[2] || '';
         const text = stripHtmlTags(rawText).trim();

--- a/src/utils/content.ts
+++ b/src/utils/content.ts
@@ -1,0 +1,461 @@
+import type { IndexItem, Page } from '../types';
+
+/**
+ * Normalizes line endings to Unix-style (LF).
+ *
+ * @param text - Text with potentially mixed line endings
+ * @returns Text with normalized \n line endings
+ */
+export const normalizeLineEndings = (text: string): string => {
+    return text.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+};
+
+/**
+ * Strips all HTML tags from content, keeping only text.
+ *
+ * @param html - HTML content
+ * @returns Plain text content
+ */
+export const stripHtmlTags = (html: string): string => {
+    return html.replace(/<[^>]*>/g, '');
+};
+
+/**
+ * Detects if a paragraph is a header/section title.
+ * Headers typically contain text in parentheses like (قَوْلُهُ بَابُ ...) or (بَابُ ...)
+ *
+ * @param text - The paragraph text content
+ * @returns True if the text appears to be a header
+ */
+export const isHeaderParagraph = (text: string): boolean => {
+    const trimmed = text.trim();
+    // Check if text is wrapped in parentheses
+    if (!trimmed.startsWith('(') || !trimmed.endsWith(')')) {
+        return false;
+    }
+    // Check for common header markers (with or without diacritics)
+    // Using base letters without diacritics for matching
+    const normalized = trimmed.normalize('NFD').replace(/[\u0610-\u061A\u064B-\u065F\u0670]/g, '');
+    return /باب|قوله|فصل|كتاب/i.test(normalized);
+};
+
+/**
+ * Converts ketabonline HTML content to Markdown format.
+ *
+ * Transformations:
+ * - `<p>` tags with header content → `## heading`
+ * - Regular `<p>` tags → text with double newline
+ * - `<span>` tags → text only (strips the tag)
+ * - All other tags → stripped
+ *
+ * @param html - HTML content from ketabonline
+ * @returns Markdown-formatted content
+ */
+export const htmlToMarkdown = (html: string): string => {
+    if (!html) {
+        return '';
+    }
+
+    let result = html;
+
+    // Extract paragraphs and convert to markdown
+    result = result.replace(/<p[^>]*>([\s\S]*?)<\/p>/gi, (_, content) => {
+        // Strip inner HTML tags from paragraph content
+        const text = stripHtmlTags(content).trim();
+
+        if (!text) {
+            return '';
+        }
+
+        // Check if this is a header paragraph
+        if (isHeaderParagraph(text)) {
+            return `## ${text}\n\n`;
+        }
+
+        return `${text}\n\n`;
+    });
+
+    // Strip any remaining HTML tags
+    result = stripHtmlTags(result);
+
+    // Normalize line endings and clean up excessive whitespace
+    result = normalizeLineEndings(result);
+    result = result.replace(/\n{3,}/g, '\n\n').trim();
+
+    return result;
+};
+
+/**
+ * Extracts plain text content from a Page object.
+ *
+ * @param page - The page to extract text from
+ * @returns Plain text content of the page
+ */
+export const extractPageText = (page: Page): string => {
+    return stripHtmlTags(page.content);
+};
+
+/**
+ * Converts a Page's HTML content to Markdown.
+ *
+ * @param page - The page to convert
+ * @returns Markdown-formatted content
+ */
+export const pageToMarkdown = (page: Page): string => {
+    return htmlToMarkdown(page.content);
+};
+
+/**
+ * Converts an array of pages to a single Markdown document.
+ *
+ * @param pages - Array of pages to convert
+ * @param options - Conversion options
+ * @returns Combined Markdown content
+ */
+export const pagesToMarkdown = (
+    pages: Page[],
+    options: { includePageNumbers?: boolean; separator?: string } = {},
+): string => {
+    const { includePageNumbers = false, separator = '\n---\n\n' } = options;
+
+    return pages
+        .map((page) => {
+            const markdown = pageToMarkdown(page);
+            if (includePageNumbers && page.part) {
+                return `<!-- Page ${page.page}, Part ${page.part.name} -->\n${markdown}`;
+            }
+            return markdown;
+        })
+        .join(separator);
+};
+
+/**
+ * Flattens a hierarchical index structure into a flat array.
+ *
+ * @param index - Hierarchical index array
+ * @returns Flat array of all index entries
+ */
+export const flattenIndex = (index: IndexItem[]): IndexItem[] => {
+    const result: IndexItem[] = [];
+
+    const traverse = (items: IndexItem[]) => {
+        for (const item of items) {
+            result.push(item);
+            if (item.children && item.children.length > 0) {
+                traverse(item.children);
+            }
+        }
+    };
+
+    traverse(index);
+    return result;
+};
+
+/**
+ * Finds an index entry by its ID.
+ *
+ * @param index - Hierarchical or flat index array
+ * @param id - The ID to search for
+ * @returns The matching index entry, or undefined if not found
+ */
+export const findIndexEntry = (index: IndexItem[], id: number): IndexItem | undefined => {
+    for (const item of index) {
+        if (item.id === id) {
+            return item;
+        }
+        if (item.children && item.children.length > 0) {
+            const found = findIndexEntry(item.children, id);
+            if (found) {
+                return found;
+            }
+        }
+    }
+    return undefined;
+};
+
+/**
+ * Builds a breadcrumb path from an index entry back to the root.
+ *
+ * @param index - Hierarchical index array
+ * @param entryId - The ID of the entry to build breadcrumb for
+ * @returns Array of index entries from root to the target entry
+ */
+export const getIndexBreadcrumb = (index: IndexItem[], entryId: number): IndexItem[] => {
+    const path: IndexItem[] = [];
+
+    const findPath = (items: IndexItem[], targetId: number): boolean => {
+        for (const item of items) {
+            if (item.id === targetId) {
+                path.push(item);
+                return true;
+            }
+            if (item.children && item.children.length > 0) {
+                if (findPath(item.children, targetId)) {
+                    path.unshift(item);
+                    return true;
+                }
+            }
+        }
+        return false;
+    };
+
+    findPath(index, entryId);
+    return path;
+};
+
+/**
+ * Gets all pages that belong to a specific index entry.
+ *
+ * @param pages - Array of all pages
+ * @param indexId - The index entry ID to filter by
+ * @returns Pages that belong to this index entry
+ */
+export const getPagesForIndex = (pages: Page[], indexId: number): Page[] => {
+    return pages.filter((page) => page.index === indexId);
+};
+
+/**
+ * Gets a page by its page number.
+ *
+ * @param pages - Array of all pages
+ * @param pageNumber - The page number to find
+ * @returns The matching page, or undefined if not found
+ */
+export const getPageByNumber = (pages: Page[], pageNumber: number): Page | undefined => {
+    return pages.find((page) => page.page === pageNumber);
+};
+
+/**
+ * Gets all pages that belong to a specific part/volume.
+ *
+ * @param pages - Array of all pages
+ * @param partName - The part name to filter by
+ * @returns Pages that belong to this part
+ */
+export const getPagesByPart = (pages: Page[], partName: string): Page[] => {
+    return pages.filter((page) => page.part?.name === partName);
+};
+
+/**
+ * Converts an index structure to Markdown table of contents.
+ *
+ * @param index - Hierarchical index array
+ * @param options - Conversion options
+ * @returns Markdown-formatted table of contents
+ */
+export const indexToMarkdown = (index: IndexItem[], options: { maxDepth?: number } = {}): string => {
+    const { maxDepth = Infinity } = options;
+    const lines: string[] = [];
+
+    const traverse = (items: IndexItem[], depth: number) => {
+        if (depth > maxDepth) {
+            return;
+        }
+
+        for (const item of items) {
+            const indent = '  '.repeat(depth - 1);
+            const prefix = depth === 1 ? '##' : '-';
+            const pageInfo = item.part_name ? ` (Part ${item.part_name}, p. ${item.page})` : ` (p. ${item.page})`;
+
+            if (depth === 1) {
+                lines.push(`${prefix} ${item.title}${pageInfo}`);
+            } else {
+                lines.push(`${indent}${prefix} ${item.title}${pageInfo}`);
+            }
+
+            if (item.children && item.children.length > 0) {
+                traverse(item.children, depth + 1);
+            }
+        }
+    };
+
+    traverse(index, 1);
+    return lines.join('\n');
+};
+
+// ============================================================================
+// Footnote Utilities
+// ============================================================================
+
+/** The HTML element that separates page body from footnotes */
+const FOOTNOTE_SEPARATOR = '<div class="g-page-footer">';
+
+/**
+ * Represents a footnote extracted from page content.
+ */
+export interface Footnote {
+    /** The footnote number (e.g., 1, 2, 3) */
+    number: number;
+    /** The footnote text content */
+    text: string;
+}
+
+/**
+ * Splits page HTML content into body and footer (footnotes) sections.
+ *
+ * ketabonline uses `<div class="g-page-footer">` to separate the main
+ * content from footnotes at the bottom of the page.
+ *
+ * @param html - The full page HTML content
+ * @returns A tuple of [body, footer] HTML strings
+ *
+ * @example
+ * ```typescript
+ * const [body, footer] = splitPageFootnotes(page.content);
+ * const mainText = htmlToMarkdown(body);
+ * const footnotes = extractFootnotes(footer);
+ * ```
+ */
+export const splitPageFootnotes = (html: string): readonly [string, string] => {
+    if (!html) {
+        return ['', ''] as const;
+    }
+
+    const separatorIndex = html.indexOf(FOOTNOTE_SEPARATOR);
+    if (separatorIndex === -1) {
+        return [html, ''] as const;
+    }
+
+    const body = html.slice(0, separatorIndex);
+    const footer = html.slice(separatorIndex);
+
+    return [body, footer] as const;
+};
+
+/**
+ * Removes footnote reference links from HTML content.
+ *
+ * Strips `<a class="g-footnote-link">` tags while keeping the reference number text.
+ * Use this when you want to show the footnote numbers but not as clickable links.
+ *
+ * @param html - HTML content containing footnote links
+ * @returns HTML with footnote links replaced by plain text
+ *
+ * @example
+ * ```typescript
+ * // Input: 'Text <a href="#foot-1" class="g-footnote-link">(١)</a> more'
+ * // Output: 'Text (١) more'
+ * ```
+ */
+export const stripFootnoteLinks = (html: string): string => {
+    if (!html) {
+        return '';
+    }
+
+    // Remove <a> tags with g-footnote-link class, keeping the text inside
+    return html.replace(/<a[^>]*class="g-footnote-link"[^>]*>(.*?)<\/a>/gi, '$1');
+};
+
+/**
+ * Removes all footnote references from HTML content completely.
+ *
+ * Removes `<span class="g-parentheses">` containing footnote links entirely,
+ * including the reference numbers. Use this for a clean reading experience.
+ *
+ * @param html - HTML content containing footnote references
+ * @returns HTML with footnote references completely removed
+ *
+ * @example
+ * ```typescript
+ * // Input: 'Text <span class="g-parentheses"><a href="#foot-1">(١)</a></span> more'
+ * // Output: 'Text  more'
+ * ```
+ */
+export const removeFootnoteReferences = (html: string): string => {
+    if (!html) {
+        return '';
+    }
+
+    // Remove spans containing footnote links
+    return html.replace(
+        /<span[^>]*class="g-parentheses"[^>]*>\s*<a[^>]*class="g-footnote-link"[^>]*>.*?<\/a>\s*<\/span>/gi,
+        '',
+    );
+};
+
+/**
+ * Extracts structured footnote data from the footer HTML.
+ *
+ * Parses the footer section to extract individual footnotes with their
+ * numbers and text content.
+ *
+ * @param footerHtml - The footer section HTML (from splitPageFootnotes)
+ * @returns Array of Footnote objects with number and text
+ *
+ * @example
+ * ```typescript
+ * const [, footer] = splitPageFootnotes(page.content);
+ * const footnotes = extractFootnotes(footer);
+ * // [{ number: 1, text: 'Reference to "تاريخ الإسلام" (5/378).' }, ...]
+ * ```
+ */
+export const extractFootnotes = (footerHtml: string): Footnote[] => {
+    if (!footerHtml) {
+        return [];
+    }
+
+    const footnotes: Footnote[] = [];
+
+    // Match footnote target spans and capture the number and following content
+    // Pattern: <span id="foot-N" class="g-footnote-target">(N)</span> followed by text
+    const footnoteRegex =
+        /<span[^>]*id="foot-(\d+)"[^>]*class="g-footnote-target"[^>]*>\([^)]*\)<\/span>\s*([\s\S]*?)(?=<span[^>]*class="g-list"|<\/div>|$)/gi;
+
+    let match;
+    while ((match = footnoteRegex.exec(footerHtml)) !== null) {
+        const number = parseInt(match[1]!, 10);
+        const rawText = match[2] || '';
+        const text = stripHtmlTags(rawText).trim();
+
+        if (text) {
+            footnotes.push({ number, text });
+        }
+    }
+
+    return footnotes;
+};
+
+/**
+ * Checks if a page has footnotes.
+ *
+ * @param html - The page HTML content
+ * @returns True if the page contains a footnote section
+ */
+export const hasFootnotes = (html: string): boolean => {
+    return html.includes(FOOTNOTE_SEPARATOR);
+};
+
+/**
+ * Converts page HTML to Markdown, optionally including footnotes as a separate section.
+ *
+ * @param html - The full page HTML content
+ * @param options - Conversion options
+ * @returns Markdown-formatted content
+ *
+ * @example
+ * ```typescript
+ * const md = pageToMarkdownWithFootnotes(page.content, { includeFootnotes: true });
+ * ```
+ */
+export const pageToMarkdownWithFootnotes = (
+    html: string,
+    options: { includeFootnotes?: boolean; footnoteSeparator?: string } = {},
+): string => {
+    const { includeFootnotes = true, footnoteSeparator = '\n\n---\n\n' } = options;
+
+    const [body, footer] = splitPageFootnotes(html);
+    const bodyMarkdown = htmlToMarkdown(body);
+
+    if (!includeFootnotes || !footer) {
+        return bodyMarkdown;
+    }
+
+    const footnotes = extractFootnotes(footer);
+    if (footnotes.length === 0) {
+        return bodyMarkdown;
+    }
+
+    const footnotesMarkdown = footnotes.map((fn) => `[^${fn.number}]: ${fn.text}`).join('\n');
+
+    return `${bodyMarkdown}${footnoteSeparator}${footnotesMarkdown}`;
+};

--- a/src/utils/io.test.ts
+++ b/src/utils/io.test.ts
@@ -30,8 +30,8 @@ describe('io', () => {
                 'book.json': new Uint8Array([123, 34, 102, 111, 111, 34, 58, 34, 98, 97, 114, 34, 125]),
             });
 
-            // Import after setting up mocks
-            const { unzipFromUrl } = await import('./io');
+            // Import with cache-busting after setting up mocks
+            const { unzipFromUrl } = await import(`./io?t=${Date.now()}`);
             const result = await unzipFromUrl('https://example.com/archive.zip');
 
             expect(result).toEqual([

--- a/src/utils/io.test.ts
+++ b/src/utils/io.test.ts
@@ -1,24 +1,7 @@
 import { beforeEach, describe, expect, it, mock } from 'bun:test';
 
-const mkdtempMock = mock();
 const httpsGetMock = mock();
 const unzipSyncMock = mock();
-
-mock.module('node:fs', () => ({
-    default: {
-        promises: {
-            mkdtemp: mkdtempMock,
-        },
-    },
-    promises: {
-        mkdtemp: mkdtempMock,
-    },
-}));
-
-mock.module('node:https', () => ({
-    default: { get: mock() },
-    get: mock(),
-}));
 
 mock.module('./network', () => ({
     buildUrl: (endpoint: string, params: Record<string, string | number>) => {
@@ -32,8 +15,6 @@ mock.module('./network', () => ({
 mock.module('fflate', () => ({
     unzipSync: unzipSyncMock,
 }));
-
-const { unzipFromUrl } = await import('./io');
 
 describe('io', () => {
     describe('unzipFromUrl', () => {
@@ -49,6 +30,8 @@ describe('io', () => {
                 'book.json': new Uint8Array([123, 34, 102, 111, 111, 34, 58, 34, 98, 97, 114, 34, 125]),
             });
 
+            // Import after setting up mocks
+            const { unzipFromUrl } = await import('./io');
             const result = await unzipFromUrl('https://example.com/archive.zip');
 
             expect(result).toEqual([
@@ -57,6 +40,21 @@ describe('io', () => {
                     name: 'book.json',
                 },
             ]);
+        });
+
+        it('should throw when unzip fails', async () => {
+            const mockData = new Uint8Array([1, 2, 3]);
+            httpsGetMock.mockResolvedValue(mockData);
+            unzipSyncMock.mockImplementation(() => {
+                throw new Error('Invalid zip data');
+            });
+
+            // Import with a cache-busting query param
+            const ioModule = await import('./io?error-test');
+
+            await expect(ioModule.unzipFromUrl('https://example.com/archive.zip')).rejects.toThrow(
+                'Error processing URL: Invalid zip data',
+            );
         });
     });
 });

--- a/src/utils/io.ts
+++ b/src/utils/io.ts
@@ -1,6 +1,3 @@
-import { promises as fs } from 'node:fs';
-import os from 'node:os';
-import path from 'node:path';
 import { unzipSync } from 'fflate';
 import { httpsGet } from './network';
 
@@ -12,17 +9,6 @@ export type UnzippedEntry = {
     name: string;
     /** Entry data as bytes */
     data: Uint8Array;
-};
-
-/**
- * Creates a temporary directory inside the operating system's temp folder.
- *
- * @param prefix - The prefix to use for the temporary directory name.
- * @returns A promise that resolves with the path to the created directory.
- */
-export const createTempDir = async (prefix: string): Promise<string> => {
-    const tempDirBase = path.join(os.tmpdir(), prefix);
-    return fs.mkdtemp(tempDirBase);
 };
 
 /**

--- a/testing/e2e.test.ts
+++ b/testing/e2e.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, mock, test } from 'bun:test';
 import { EventEmitter } from 'node:events';
-import { getAuthorInfo, getBookInfo, getCategoryInfo, getBookContents, getBooks } from '../src/index';
+import { getAuthorInfo, getBookContents, getBookInfo, getBooks, getCategoryInfo } from '../src/index';
 
 mock.module('unzipper', () => ({
     default: { Parse: () => new EventEmitter() },
@@ -8,7 +8,6 @@ mock.module('unzipper', () => ({
 }));
 
 const e2eDescribe = process.env.RUN_E2E === 'true' ? describe : describe.skip;
-
 
 e2eDescribe('e2e', () => {
     describe('getBookInfo', () => {
@@ -85,7 +84,7 @@ e2eDescribe('e2e', () => {
         test(
             'should handle 404',
             async () => {
-                await expect(getBookInfo(10000)).rejects.toThrow('Book 10000 not found');
+                await expect(getBookInfo(10000)).rejects.toThrow('Error making request: 404 Not Found');
             },
             { timeout: 5000 },
         );
@@ -113,12 +112,12 @@ e2eDescribe('e2e', () => {
             const result = await getCategoryInfo(2);
             expect(result).toEqual(
                 expect.objectContaining({
-                    name: 'التفاسير',
-                    image_url: expect.any(String),
-                    created_at: '2019-10-24 10:57:53',
-                    is_active: 1,
                     books_count: expect.any(Number),
+                    created_at: '2019-10-24 10:57:53',
+                    image_url: expect.any(String),
+                    is_active: 1,
                     lang: 'ar',
+                    name: 'التفاسير',
                 }),
             );
         });

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'tsdown';
 export default defineConfig({
     clean: true,
     dts: true,
-    entry: ['src/index.ts'],
+    entry: ['src/index.ts', 'src/node.ts'],
     format: ['esm'],
     outDir: 'dist',
     sourcemap: true,


### PR DESCRIPTION
Add 20 utility functions to transform ketabonline HTML content to Markdown and navigate book data structures.

Content Utilities:
- htmlToMarkdown: Convert ketabonline HTML to Markdown with header detection
- stripHtmlTags, normalizeLineEndings, isHeaderParagraph: HTML helpers

Footnote Handling:
- splitPageFootnotes: Split page content into [body, footer] tuple
- extractFootnotes: Parse footnotes into { number, text }[] structure
- stripFootnoteLinks: Remove <a> tags but keep reference numbers
- removeFootnoteReferences: Remove all footnote references completely
- hasFootnotes, pageToMarkdownWithFootnotes: Additional helpers

Page Helpers:
- extractPageText, pageToMarkdown, pagesToMarkdown
- getPageByNumber, getPagesByPart, getPagesForIndex

Index/TOC Utilities:
- flattenIndex: Convert hierarchical TOC to flat array
- findIndexEntry: Find TOC entry by ID
- getIndexBreadcrumb: Build breadcrumb path from entry to root
- indexToMarkdown: Convert TOC to Markdown format

Also includes:
- URL consolidation: Added API_BASE_URL, BOOKS_CDN_URL constants and apiUrl() helper
- Export IndexItem, Page, and Footnote types for consumers
- Updated README with usage examples for content transformation
- 101 tests passing

# Content Transformation Utilities

Create utilities to convert HTML content to Markdown and helpers for consuming book data (TOC, pages, metadata).

## HTML Patterns Identified

Based on the sample data, the `content` field contains these HTML elements:

| Element | Purpose | Transformation |
|---------|---------|----------------|
| `<p class="g-paragraph g-rtl" id="p-N">` | Paragraph wrapper | Strip tag, keep content |
| `<span class="g-holy-word">` | Holy words (االله, تَعَالَى) | Keep text, strip tag |
| `<span class="g-square-brackets">` | Bracketed references `[١٢٢٦]` | Keep text, strip tag |

**Header detection**: Paragraphs with `id="p-1"` that contain bracketed text like [(قَوْلُهُ بَابُ ...)](src/types.ts#486-514) are chapter headers.

## Proposed Changes

### Content Utilities

#### [NEW] [content.ts](src/utils/content.ts)

```typescript
// Strip all HTML tags, keeping text content
export const stripHtmlTags = (html: string): string;

// Convert HTML to Markdown:
// - Header paragraphs (id="p-1" with باب) → ## heading
// - Regular paragraphs → text with double newline
// - Holy word spans → text
// - Bracket spans → text
export const htmlToMarkdown = (html: string): string;

// Normalize line endings (\r\n, \r → \n)
export const normalizeLineEndings = (text: string): string;

// Extract plain text from a Page
export const extractPageText = (page: Page): string;
```

---

### Index/TOC Utilities

#### [NEW] [index.ts helpers or content.ts additions]

```typescript
// Flatten hierarchical index to a flat array
export const flattenIndex = (index: IndexItem[]): IndexItem[];

// Get index entry by ID
export const findIndexEntry = (index: IndexItem[], id: number): IndexItem | undefined;

// Get all pages for a specific index entry
export const getPagesForIndex = (pages: Page[], indexId: number): Page[];

// Build a breadcrumb path from an index entry to root
export const getIndexBreadcrumb = (index: IndexItem[], entryId: number): IndexItem[];
```

---

### Page Utilities

```typescript
// Get page by page number
export const getPageByNumber = (pages: Page[], pageNumber: number): Page | undefined;

// Get pages for a specific part
export const getPagesByPart = (pages: Page[], partName: string): Page[];

// Convert all pages to Markdown
export const convertPagesToMarkdown = (pages: Page[]): string;
```

---

### Types Updates

#### [MODIFY] [types.ts](src/types.ts)

Export [IndexItem](src/types.ts#372-392) for consumers who work with the index structure:

```diff
+export type { IndexItem };
```

---

#### [NEW] [content.test.ts](src/utils/content.test.ts)

Tests for all content transformation utilities.

---

## Verification Plan

### Automated Tests

```bash
bun test src/utils/content.test.ts
bun test
```

### Build Verification

```bash
bun run build
bun run lint
```

# Content Transformation Utilities Walkthrough

## Summary

Added **20 utility functions** for transforming HTML content to Markdown and navigating book data structures, including full footnote support.

## Utilities Overview

### HTML-to-Markdown
| Function | Description |
|----------|-------------|
| [htmlToMarkdown(html)](src/utils/content.ts#42-87) | Convert HTML to Markdown |
| [stripHtmlTags(html)](src/utils/content.ts#13-22) | Remove all HTML tags |
| [isHeaderParagraph(text)](src/utils/content.ts#23-41) | Detect باب/فصل/كتاب headers |
| [normalizeLineEndings(text)](src/utils/content.ts#3-12) | Normalize \r\n to \n |

### Footnote Handling
| Function | Description |
|----------|-------------|
| [splitPageFootnotes(html)](src/utils/content.ts#293-324) | Split body from footer section |
| [hasFootnotes(html)](src/utils/content.ts#418-427) | Check if page has footnotes |
| [extractFootnotes(footer)](src/utils/content.ts#376-417) | Get footnotes as `{ number, text }[]` |
| [stripFootnoteLinks(html)](src/utils/content.ts#325-348) | Remove `<a>` but keep [(١)](src/types.ts#416-440) text |
| [removeFootnoteReferences(html)](src/utils/content.ts#349-375) | Remove all footnote refs entirely |
| [pageToMarkdownWithFootnotes(html)](src/utils/content.ts#428-462) | Convert with `[^N]:` footnote syntax |

### Page Helpers
| Function | Description |
|----------|-------------|
| [extractPageText(page)](src/utils/content.ts#88-97) | Get plain text from page |
| [pageToMarkdown(page)](src/utils/content.ts#98-107) | Convert page to Markdown |
| [pagesToMarkdown(pages)](src/utils/content.ts#108-131) | Batch convert pages |
| [getPageByNumber(pages, n)](src/utils/content.ts#217-227) | Find page by number |
| [getPagesByPart(pages, name)](src/utils/content.ts#228-238) | Filter by part/volume |
| [getPagesForIndex(pages, id)](src/utils/content.ts#206-216) | Get pages for TOC entry |

### Index/TOC Helpers
| Function | Description |
|----------|-------------|
| [flattenIndex(index)](src/utils/content.ts#132-153) | Hierarchical → flat array |
| [findIndexEntry(index, id)](src/utils/content.ts#154-175) | Find entry by ID |
| [getIndexBreadcrumb(index, id)](src/utils/content.ts#176-205) | Build path to root |
| [indexToMarkdown(index)](src/utils/content.ts#239-275) | Convert TOC to Markdown |

## Usage Examples

```typescript
import { 
    getBookContents, 
    splitPageFootnotes,
    extractFootnotes,
    htmlToMarkdown 
} from 'ketab-online-sdk';

// Get book and process a page with footnotes
const book = await getBookContents(62952);
const page = book.pages[99];

// Split body from footer
const [body, footer] = splitPageFootnotes(page.content);

// Convert body to clean markdown
const markdown = htmlToMarkdown(body);

// Get structured footnotes
const footnotes = extractFootnotes(footer);
// [{ number: 1, text: '"تاريخ الإسلام" (٥/ ٣٧٨).' }, ...]
```

## Verification

| Check | Result |
|-------|--------|
| Tests | ✅ 101 pass, 0 fail |
| Build | ✅ Both entry points generated |

# Content Transformation Utilities

## Objective
Create utility functions to transform HTML content from ketabonline books into Markdown and provide helpers for consuming book data.

## Tasks

### Planning
- [x] Review [types.ts](src/types.ts) to understand data structures
- [x] Analyze sample book JSON to identify HTML patterns
- [x] Create implementation plan

### Execution
- [x] Create [src/utils/content.ts](src/utils/content.ts) with HTML-to-Markdown utilities
- [x] Create [src/utils/content.test.ts](src/utils/content.test.ts) with tests
- [x] Add index/TOC helper functions
- [x] Export new utilities from [src/index.ts](src/index.ts)
- [x] Update types ([IndexItem](src/types.ts#372-392) now exported)

### Verification
- [x] Run `bun test` to verify tests pass (62 pass, 0 fail)
- [x] Run `bun run build` to verify build succeeds


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds rich content transformation utilities (HTML→Markdown, footnote extraction/handling, TOC/index helpers).
  * Introduces a browser-first public entry and a separate Node-only export for file downloads.

* **Documentation**
  * Clarifies browser vs. Node entry points, runtime compatibility, data flow, and fetch-mocking guidance.

* **Tests**
  * Expands unit and Node tests; network/IO tests now use fetch-based mocks.

* **Chores**
  * Dev tooling and package metadata updated (version bump to 1.3.0).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->